### PR TITLE
secure ID

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id("org.example.age.java-conventions")
+    `java-library`
+}
+
+dependencies {
+    compileOnly("org.immutables:value-annotations:2.9.3")
+    annotationProcessor("org.immutables:value:2.9.3")
+
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
+
+    testImplementation("com.google.guava:guava-testlib:32.1.1-jre")
+}

--- a/data/src/main/java/org/example/age/PackageImplementation.java
+++ b/data/src/main/java/org/example/age/PackageImplementation.java
@@ -1,0 +1,9 @@
+package org.example.age;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import org.immutables.value.Value;
+
+@Target(ElementType.TYPE)
+@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+public @interface PackageImplementation {}

--- a/data/src/main/java/org/example/age/data/SecureId.java
+++ b/data/src/main/java/org/example/age/data/SecureId.java
@@ -1,0 +1,136 @@
+package org.example.age.data;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/** 256 random bits, generated via a secure random number generator. Can also be used as a key. */
+@JsonSerialize(using = ToStringSerializer.class)
+@JsonDeserialize(using = SecureId.Deserializer.class)
+public final class SecureId {
+
+    private static final SecureRandom random = new SecureRandom();
+    private static final Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+    private static final Base64.Decoder decoder = Base64.getUrlDecoder();
+
+    private final byte[] bytes;
+
+    /** Generates a new ID. */
+    public static SecureId generate() {
+        byte[] bytes = generate256Bits();
+        return new SecureId(bytes);
+    }
+
+    /** Creates an ID from a copy of the raw bytes. */
+    public static SecureId ofBytes(byte[] bytes) {
+        checkHas256Bits(bytes);
+        return new SecureId(Arrays.copyOf(bytes, bytes.length));
+    }
+
+    /** Creates an ID from a URL-friendly base64 string. */
+    public static SecureId fromString(String value) {
+        byte[] bytes = decoder.decode(value);
+        checkHas256Bits(bytes);
+        return new SecureId(bytes);
+    }
+
+    /** Gets a copy of the raw bytes. */
+    public byte[] getBytes() {
+        return Arrays.copyOf(bytes, bytes.length);
+    }
+
+    /**
+     * Produces a new ID based on a key.
+     *
+     * <p>It is impossible to figure out the original ID from the new ID,
+     * and it is impossible to figure out the new ID from the original ID (without knowledge of the key).</p>
+     */
+    public SecureId localize(SecureId key) {
+        Mac hmacGenerator = Macs.createHmacGenerator(key.getBytes());
+        byte[] localBytes = hmacGenerator.doFinal(bytes);
+        return new SecureId(localBytes);
+    }
+
+    /** Converts the ID to a URL-friendly base64 string. */
+    @Override
+    public String toString() {
+        return encoder.encodeToString(bytes);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        SecureId other = (o instanceof SecureId) ? (SecureId) o : null;
+        if (other == null) {
+            return false;
+        }
+
+        return Arrays.equals(bytes, other.bytes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(bytes);
+    }
+
+    /** Randomly generates 256 bits. */
+    private static byte[] generate256Bits() {
+        byte[] bytes = new byte[32];
+        random.nextBytes(bytes);
+        return bytes;
+    }
+
+    /** Checks that we have 256 bits (or 32 bytes). */
+    private static void checkHas256Bits(byte[] bytes) {
+        if (bytes.length != 32) {
+            throw new IllegalArgumentException("secure ID must have 256 bits");
+        }
+    }
+
+    private SecureId(byte[] bytes) {
+        this.bytes = bytes;
+    }
+
+    /** Creates {@link Mac}'s. */
+    private static final class Macs {
+
+        private static final String ALGORITHM = "HmacSHA256";
+
+        /** Creates an HMAC generator. */
+        public static Mac createHmacGenerator(byte[] rawKey) {
+            try {
+                Mac hmacGenerator = Mac.getInstance(ALGORITHM);
+                Key hmacKey = new SecretKeySpec(rawKey, ALGORITHM);
+                hmacGenerator.init(hmacKey);
+                return hmacGenerator;
+            } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+                throw new RuntimeException("unexpected error", e);
+            }
+        }
+
+        // static class
+        private Macs() {}
+    }
+
+    /** JSON {@code fromString()} deserializer. */
+    static final class Deserializer extends FromStringDeserializer<SecureId> {
+
+        public Deserializer() {
+            super(SecureId.class);
+        }
+
+        @Override
+        protected SecureId _deserialize(String value, DeserializationContext context) {
+            return SecureId.fromString(value);
+        }
+    }
+}

--- a/data/src/test/java/org/example/age/data/SecureIdTest.java
+++ b/data/src/test/java/org/example/age/data/SecureIdTest.java
@@ -1,0 +1,105 @@
+package org.example.age.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.testing.EqualsTester;
+import java.util.Arrays;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public final class SecureIdTest {
+
+    private static final byte[] ID_BYTES = new byte[] {
+        -31, 98, -36, -70, -19, 26, 103, 100, -116, -60, 47, 69, 97, 84, 30, -128, -85, -5, -46, 46, 53, -24, 47, -28,
+        -11, -11, -92, 98, 54, 33, 66, 80
+    };
+    private static final String ID_STRING = "4WLcuu0aZ2SMxC9FYVQegKv70i416C_k9fWkYjYhQlA";
+
+    private static ObjectMapper mapper;
+
+    @BeforeAll
+    public static void createMapper() {
+        mapper = new ObjectMapper();
+    }
+
+    @Test
+    public void generate() {
+        SecureId id = SecureId.generate();
+        assertThat(id.getBytes()).hasSize(32);
+        assertThat(id.toString()).hasSize(43);
+    }
+
+    @Test
+    public void localize() {
+        SecureId id = SecureId.generate();
+        SecureId key = SecureId.generate();
+        SecureId localId = id.localize(key);
+        assertThat(localId).isNotEqualTo(id);
+        assertThat(localId.getBytes()).hasSize(32);
+        assertThat(localId.toString()).hasSize(43);
+    }
+
+    @Test
+    public void toString_() {
+        SecureId id = SecureId.ofBytes(ID_BYTES);
+        assertThat(id.toString()).isEqualTo(ID_STRING);
+    }
+
+    @Test
+    public void fromString() {
+        SecureId id = SecureId.fromString(ID_STRING);
+        assertThat(id.getBytes()).isEqualTo(ID_BYTES);
+    }
+
+    @Test
+    public void serializeThenDeserialize() throws JsonProcessingException {
+        SecureId id = SecureId.generate();
+        String json = mapper.writeValueAsString(id);
+        SecureId deserializedId = mapper.readValue(json, SecureId.class);
+        assertThat(deserializedId).isEqualTo(id);
+    }
+
+    @Test
+    public void equals() {
+        SecureId id1 = SecureId.generate();
+        SecureId id2 = SecureId.ofBytes(id1.getBytes());
+        SecureId id3 = SecureId.generate();
+        new EqualsTester().addEqualityGroup(id1, id2).addEqualityGroup(id3).testEquals();
+    }
+
+    @Test
+    public void copyOnCreate() {
+        byte[] bytes = Arrays.copyOf(ID_BYTES, ID_BYTES.length);
+        SecureId id = SecureId.ofBytes(bytes);
+        bytes[0] = 0;
+        assertThat(id.getBytes()[0]).isNotEqualTo(bytes[0]);
+    }
+
+    @Test
+    public void copyOnRead() {
+        SecureId id = SecureId.ofBytes(Arrays.copyOf(ID_BYTES, ID_BYTES.length));
+        byte[] bytes = id.getBytes();
+        bytes[0] = 0;
+        assertThat(id.getBytes()[0]).isNotEqualTo(bytes[0]);
+    }
+
+    @Test
+    public void error_IllegalLength_OfBytes() {
+        error_IllegalLength(() -> SecureId.ofBytes(new byte[4]));
+    }
+
+    @Test
+    public void error_IllegalLength_FromString() {
+        error_IllegalLength(() -> SecureId.fromString("123456"));
+    }
+
+    private void error_IllegalLength(ThrowableAssert.ThrowingCallable callable) {
+        assertThatThrownBy(callable)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("secure ID must have 256 bits");
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 rootProject.name = "age-verification"
 
 include(
+        "data",
         "demo",
 )


### PR DESCRIPTION
- `SecureId` is 256 random bits (using a secure random number generator)
- Provides a URL-friendly base64 encoding of an ID
- Can use a key (also a `SecureId`) to produce a new ID