### PR TITLE
verified users

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     annotationProcessor("org.immutables:value:2.9.3")
 
     implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-guava:2.15.2")
 
     testImplementation("com.google.guava:guava-testlib:32.1.1-jre")
 }

--- a/data/src/main/java/org/example/age/data/VerifiedUser.java
+++ b/data/src/main/java/org/example/age/data/VerifiedUser.java
@@ -1,0 +1,62 @@
+package org.example.age.data;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+import org.example.age.PackageImplementation;
+import org.immutables.value.Value;
+
+/**
+ * User whose age and guardians (if applicable) are verified.
+ *
+ * <p>The only PII a {@link VerifiedUser} contains is an age, which can be anonymized into an age range.</p>
+ */
+@Value.Immutable
+@PackageImplementation
+@JsonSerialize(as = ImmutableVerifiedUser.class)
+@JsonDeserialize(as = ImmutableVerifiedUser.class)
+public interface VerifiedUser {
+
+    /** Creates a verified user. */
+    static VerifiedUser of(SecureId id, AgeRange ageRange, List<SecureId> guardianIds) {
+        return ImmutableVerifiedUser.builder()
+                .id(id)
+                .ageRange(ageRange)
+                .guardianIds(guardianIds)
+                .build();
+    }
+
+    /** Creates a verified user without guardians. */
+    static VerifiedUser of(SecureId id, int age) {
+        return of(id, age, List.of());
+    }
+
+    /** Creates a verified user with guardians. */
+    static VerifiedUser of(SecureId id, int age, List<SecureId> guardianIds) {
+        AgeRange ageRange = AgeRange.at(age);
+        return of(id, ageRange, guardianIds);
+    }
+
+    /** ID of the user. */
+    SecureId id();
+
+    /** Age range of the user. */
+    AgeRange ageRange();
+
+    /** IDs of the guardians, if the user is a minor. */
+    List<SecureId> guardianIds();
+
+    /** Produces a new set of IDs using the key. */
+    default VerifiedUser localize(SecureId key) {
+        SecureId localId = id().localize(key);
+        List<SecureId> localGuardianIds =
+                guardianIds().stream().map(id -> id.localize(key)).toList();
+        return of(localId, ageRange(), localGuardianIds);
+    }
+
+    /** Anonymizes the age based on the age thresholds. */
+    default VerifiedUser anonymizeAge(AgeThresholds ageThresholds) {
+        AgeRange anonymizedAgeRange = ageThresholds.anonymize(ageRange());
+        return of(id(), anonymizedAgeRange, guardianIds());
+    }
+}

--- a/data/src/test/java/org/example/age/data/VerifiedUserTest.java
+++ b/data/src/test/java/org/example/age/data/VerifiedUserTest.java
@@ -1,0 +1,55 @@
+package org.example.age.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public final class VerifiedUserTest {
+
+    private static ObjectMapper mapper;
+
+    @BeforeAll
+    public static void createMapper() {
+        mapper = new ObjectMapper();
+        mapper.registerModule(new GuavaModule());
+    }
+
+    @Test
+    public void localize() {
+        SecureId parentId = SecureId.generate();
+        SecureId childId = SecureId.generate();
+        VerifiedUser parent = VerifiedUser.of(parentId, 40);
+        VerifiedUser child = VerifiedUser.of(childId, 13, List.of(parentId));
+
+        SecureId key = SecureId.generate();
+        VerifiedUser localParent = parent.localize(key);
+        VerifiedUser localChild = child.localize(key);
+        assertThat(localParent.id()).isNotEqualTo(parent.id());
+        assertThat(localParent.ageRange()).isEqualTo(parent.ageRange());
+        assertThat(localParent.guardianIds()).isEmpty();
+        assertThat(localChild.id()).isNotEqualTo(child.id());
+        assertThat(localChild.ageRange()).isEqualTo(child.ageRange());
+        assertThat(localChild.guardianIds()).containsExactly(localParent.id());
+    }
+
+    @Test
+    public void anonymizeAge() {
+        VerifiedUser user = VerifiedUser.of(SecureId.generate(), 40);
+        AgeThresholds ageThresholds = AgeThresholds.of(18);
+        VerifiedUser anonymizedUser = user.anonymizeAge(ageThresholds);
+        assertThat(anonymizedUser.ageRange()).isEqualTo(AgeRange.atOrAbove(18));
+    }
+
+    @Test
+    public void serializeThenDeserialize() throws JsonProcessingException {
+        VerifiedUser user = VerifiedUser.of(SecureId.generate(), 18);
+        String json = mapper.writeValueAsString(user);
+        VerifiedUser deserializedUser = mapper.readValue(json, VerifiedUser.class);
+        assertThat(deserializedUser).isEqualTo(user);
+    }
+}


### PR DESCRIPTION
- The only PII  a `VerifiedUser` contains is age; `SecureId`'s are used in place of, e.g., full names.
- A new set of IDs can be produced using a key.
- The age can be anonymized into an age range.