### PR TITLE
add serializable auth token

### DIFF
--- a/data/src/main/java/org/example/age/certificate/AuthKey.java
+++ b/data/src/main/java/org/example/age/certificate/AuthKey.java
@@ -1,0 +1,76 @@
+package org.example.age.certificate;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.example.age.internal.ImmutableBytes;
+import org.example.age.internal.StaticFromStringDeserializer;
+
+/** Ephemeral AES-256 key used for encrypting authentication data. */
+@JsonSerialize(using = ToStringSerializer.class)
+@JsonDeserialize(using = AuthKey.Deserializer.class)
+public final class AuthKey extends ImmutableBytes {
+
+    private final SecretKey secretKey;
+
+    /** Generates a new key. */
+    public static AuthKey generate() {
+        return new AuthKey();
+    }
+
+    /** Creates a key from a copy of the raw bytes. */
+    public static AuthKey ofBytes(byte[] bytes) {
+        return new AuthKey(bytes);
+    }
+
+    /** Creates a key from URL-friendly base64 text. */
+    public static AuthKey fromString(String value) {
+        return new AuthKey(value);
+    }
+
+    /** Converts the key to a {@link SecretKey}. */
+    public SecretKey toSecretKey() {
+        return secretKey;
+    }
+
+    @Override
+    protected int expectedLength() {
+        return 32;
+    }
+
+    private AuthKey() {
+        secretKey = SecretKeys.createAesKey(bytes);
+    }
+
+    private AuthKey(byte[] bytes) {
+        super(bytes);
+        secretKey = SecretKeys.createAesKey(bytes);
+    }
+
+    private AuthKey(String value) {
+        super(value);
+        secretKey = SecretKeys.createAesKey(bytes);
+    }
+
+    /** Creates {@link SecretKey}'s. */
+    private static final class SecretKeys {
+
+        /** Creates an AES key. */
+        public static SecretKey createAesKey(byte[] rawKey) {
+            return new SecretKeySpec(rawKey, "AES");
+        }
+
+        // static class
+        private SecretKeys() {}
+    }
+
+    /** JSON {@code fromString()} deserializer. */
+    static final class Deserializer extends StaticFromStringDeserializer<AuthKey> {
+
+        public Deserializer() {
+            super(AuthKey.class, AuthKey::fromString);
+        }
+    }
+}

--- a/data/src/main/java/org/example/age/certificate/AuthToken.java
+++ b/data/src/main/java/org/example/age/certificate/AuthToken.java
@@ -1,0 +1,49 @@
+package org.example.age.certificate;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.example.age.internal.ImmutableBytes;
+import org.example.age.internal.StaticFromStringDeserializer;
+
+/**
+ * Encrypted data used to assist with authentication.
+ *
+ * <p>The data could contain something such as an IP address, which is why it is encrypted.</p>
+ */
+@JsonSerialize(using = ToStringSerializer.class)
+@JsonDeserialize(using = AuthToken.Deserializer.class)
+public final class AuthToken extends ImmutableBytes {
+
+    /** Creates a token by encrypting authentication data. */
+    public static AuthToken encrypt(byte[] data, AuthKey key) {
+        byte[] bytes = EncryptionUtils.encrypt(data, key.toSecretKey());
+        return new AuthToken(bytes);
+    }
+
+    /** Creates a token from URL-friendly base64 text. */
+    public static AuthToken fromString(String value) {
+        return new AuthToken(value);
+    }
+
+    /** Decrypts the token to get the authentication data. */
+    public byte[] decrypt(AuthKey key) {
+        return EncryptionUtils.decrypt(bytes, key.toSecretKey());
+    }
+
+    private AuthToken(byte[] bytes) {
+        super(bytes);
+    }
+
+    private AuthToken(String value) {
+        super(value);
+    }
+
+    /** JSON {@code fromString()} deserializer. */
+    static final class Deserializer extends StaticFromStringDeserializer<AuthToken> {
+
+        public Deserializer() {
+            super(AuthToken.class, AuthToken::fromString);
+        }
+    }
+}

--- a/data/src/main/java/org/example/age/data/SecureId.java
+++ b/data/src/main/java/org/example/age/data/SecureId.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.example.age.internal.ImmutableBytes;
@@ -17,12 +16,9 @@ import org.example.age.internal.StaticFromStringDeserializer;
 @JsonDeserialize(using = SecureId.Deserializer.class)
 public final class SecureId extends ImmutableBytes {
 
-    private static final SecureRandom random = new SecureRandom();
-
     /** Generates a new ID. */
     public static SecureId generate() {
-        byte[] bytes = generate256Bits();
-        return new SecureId(bytes);
+        return new SecureId();
     }
 
     /** Creates an ID from a copy of the raw bytes. */
@@ -52,12 +48,7 @@ public final class SecureId extends ImmutableBytes {
         return 32;
     }
 
-    /** Randomly generates 256 bits. */
-    private static byte[] generate256Bits() {
-        byte[] bytes = new byte[32];
-        random.nextBytes(bytes);
-        return bytes;
-    }
+    private SecureId() {}
 
     private SecureId(byte[] bytes) {
         super(bytes);

--- a/data/src/main/java/org/example/age/internal/ImmutableBytes.java
+++ b/data/src/main/java/org/example/age/internal/ImmutableBytes.java
@@ -1,6 +1,7 @@
 package org.example.age.internal;
 
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Base64;
 
@@ -18,6 +19,7 @@ public abstract class ImmutableBytes {
 
     private static final Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
     private static final Base64.Decoder decoder = Base64.getUrlDecoder();
+    private static final SecureRandom random = new SecureRandom();
 
     protected final byte[] bytes;
 
@@ -31,6 +33,16 @@ public abstract class ImmutableBytes {
     protected ImmutableBytes(String value) {
         this.bytes = decoder.decode(value);
         checkLength();
+    }
+
+    /** Generates immutable bytes using a cryptographically strong random number generator. */
+    protected ImmutableBytes() {
+        if (expectedLength() == 0) {
+            throw new IllegalStateException("expected length must be set");
+        }
+
+        bytes = new byte[expectedLength()];
+        random.nextBytes(bytes);
     }
 
     /** Gets a copy of the raw bytes. */

--- a/data/src/test/java/org/example/age/certificate/AuthKeyTest.java
+++ b/data/src/test/java/org/example/age/certificate/AuthKeyTest.java
@@ -1,0 +1,46 @@
+package org.example.age.certificate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import org.example.age.testing.TestEncrypting;
+import org.junit.jupiter.api.Test;
+
+public final class AuthKeyTest {
+
+    private static final byte[] DATA = "auth-data".getBytes(StandardCharsets.UTF_8);
+
+    @Test
+    public void generate() {
+        AuthKey key = AuthKey.generate();
+        assertThat(key.bytes()).hasSize(32);
+    }
+
+    @Test
+    public void toSecretKey() throws Exception {
+        AuthKey key = AuthKey.generate();
+        byte[] iv = TestEncrypting.createGcmIv();
+        byte[] ciphertext = TestEncrypting.encryptAesGcm(DATA, key.toSecretKey(), iv);
+        byte[] plaintext = TestEncrypting.decryptAesGcm(ciphertext, key.toSecretKey(), iv);
+        assertThat(plaintext).isEqualTo(DATA);
+    }
+
+    @Test
+    public void serializeThenDeserialize() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        AuthKey key = AuthKey.generate();
+        String json = mapper.writeValueAsString(key);
+        AuthKey deserializedKey = mapper.readValue(json, AuthKey.class);
+        assertThat(deserializedKey).isEqualTo(key);
+    }
+
+    @Test
+    public void error_IllegalLength() {
+        assertThatThrownBy(() -> AuthKey.ofBytes(new byte[4]))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("expected 256 bits");
+    }
+}

--- a/data/src/test/java/org/example/age/certificate/AuthTokenTest.java
+++ b/data/src/test/java/org/example/age/certificate/AuthTokenTest.java
@@ -1,0 +1,31 @@
+package org.example.age.certificate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public final class AuthTokenTest {
+
+    private static final byte[] DATA = "auth-data".getBytes(StandardCharsets.UTF_8);
+
+    private static AuthKey key;
+
+    @BeforeAll
+    public static void generateKeys() {
+        key = AuthKey.generate();
+    }
+
+    @Test
+    public void encryptThenSerializeThenDeserializeThenDecrypt() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        AuthToken token = AuthToken.encrypt(DATA, key);
+        String json = mapper.writeValueAsString(token);
+        AuthToken deserializedToken = mapper.readValue(json, AuthToken.class);
+        byte[] decryptedData = deserializedToken.decrypt(key);
+        assertThat(decryptedData).isEqualTo(DATA);
+    }
+}

--- a/data/src/test/java/org/example/age/internal/ImmutableBytesTest.java
+++ b/data/src/test/java/org/example/age/internal/ImmutableBytesTest.java
@@ -34,6 +34,13 @@ public final class ImmutableBytesTest {
     }
 
     @Test
+    public void generate() {
+        TestObject o = TestObject.generate();
+        assertThat(o.bytes()).hasSize(32);
+        assertThat(o.bytes()).isNotEqualTo(new byte[32]);
+    }
+
+    @Test
     public void serializeThenDeserialize() throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
         TestObject o = TestObject.ofBytes(BYTES);
@@ -93,6 +100,13 @@ public final class ImmutableBytesTest {
                 .hasMessage("expected 256 bits");
     }
 
+    @Test
+    public void error_Generate_WithoutLength() {
+        assertThatThrownBy(() -> new ImmutableBytes() {})
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("expected length must be set");
+    }
+
     /** Serializable test object that's backed by 256 bits. */
     @JsonSerialize(using = ToStringSerializer.class)
     @JsonDeserialize(using = TestObject.Deserializer.class)
@@ -104,6 +118,10 @@ public final class ImmutableBytesTest {
 
         public static TestObject fromString(String value) {
             return new TestObject(value);
+        }
+
+        public static TestObject generate() {
+            return new TestObject();
         }
 
         @Override
@@ -118,6 +136,8 @@ public final class ImmutableBytesTest {
         private TestObject(String value) {
             super(value);
         }
+
+        private TestObject() {}
 
         /** JSON {@code fromString()} deserializer. */
         static final class Deserializer extends StaticFromStringDeserializer<TestObject> {


### PR DESCRIPTION
ephemeral AES-256 key is used to encrypt the authentication data

(also push random bit generation into `ImmutableBytes`)