### PR TITLE
add (encrypted) auth token to certificate

### DIFF
--- a/data/src/main/java/org/example/age/certificate/AgeCertificate.java
+++ b/data/src/main/java/org/example/age/certificate/AgeCertificate.java
@@ -10,7 +10,7 @@ import org.example.age.internal.SerializationUtils;
 import org.immutables.value.Value;
 
 /**
- * Certificate that verifies the age and guardians (if applicable) of a user.
+ * Certificate that pseudonymously verifies the age (and guardians, if applicable) of a person.
  *
  * <p>Only Ed25519 keys are supported.</p>
  */
@@ -21,10 +21,11 @@ import org.immutables.value.Value;
 public interface AgeCertificate {
 
     /** Creates an unsigned age certificate to fulfill a verification request for a verified user. */
-    static AgeCertificate of(VerificationRequest request, VerifiedUser user) {
+    static AgeCertificate of(VerificationRequest request, VerifiedUser user, AuthToken token) {
         return ImmutableAgeCertificate.builder()
                 .verificationRequest(request)
                 .verifiedUser(user)
+                .authToken(token)
                 .build();
     }
 
@@ -52,6 +53,9 @@ public interface AgeCertificate {
 
     /** Verified user. */
     VerifiedUser verifiedUser();
+
+    /** Authentication data, which is encrypted using an ephemeral key. */
+    AuthToken authToken();
 
     /** Signs the certificate. */
     default byte[] sign(PrivateKey privateKey) {

--- a/data/src/main/java/org/example/age/certificate/AuthToken.java
+++ b/data/src/main/java/org/example/age/certificate/AuthToken.java
@@ -7,7 +7,7 @@ import org.example.age.internal.ImmutableBytes;
 import org.example.age.internal.StaticFromStringDeserializer;
 
 /**
- * Encrypted data used to assist with authentication.
+ * Encrypted data used to assist with authentication. Can also be empty.
  *
  * <p>The data could contain something such as an IP address, which is why it is encrypted.</p>
  */
@@ -21,13 +21,25 @@ public final class AuthToken extends ImmutableBytes {
         return new AuthToken(bytes);
     }
 
+    /** Creates an empty token. */
+    public static AuthToken empty() {
+        // 0 bytes triggers a deserialization error. (An encrypted token has at least 12 bytes for the IV.)
+        return new AuthToken(new byte[1]);
+    }
+
     /** Creates a token from URL-friendly base64 text. */
     public static AuthToken fromString(String value) {
         return new AuthToken(value);
     }
 
+    /** Determines if the token is empty. */
+    public boolean isEmpty() {
+        return bytes.length == 1;
+    }
+
     /** Decrypts the token to get the authentication data. */
     public byte[] decrypt(AuthKey key) {
+        checkNotEmpty();
         return EncryptionUtils.decrypt(bytes, key.toSecretKey());
     }
 
@@ -37,6 +49,13 @@ public final class AuthToken extends ImmutableBytes {
 
     private AuthToken(String value) {
         super(value);
+    }
+
+    /** Checks that the token is not empty. */
+    private void checkNotEmpty() {
+        if (isEmpty()) {
+            throw new IllegalStateException("token is empty");
+        }
     }
 
     /** JSON {@code fromString()} deserializer. */

--- a/data/src/main/java/org/example/age/certificate/VerificationSession.java
+++ b/data/src/main/java/org/example/age/certificate/VerificationSession.java
@@ -1,0 +1,48 @@
+package org.example.age.certificate;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.example.age.internal.PackageImplementation;
+import org.example.age.internal.SerializationUtils;
+import org.immutables.value.Value;
+
+/** Session to pseudonymously verify a person's age (and guardians, if applicable). */
+@Value.Immutable
+@PackageImplementation
+@JsonSerialize(as = ImmutableVerificationSession.class)
+@JsonDeserialize(as = ImmutableVerificationSession.class)
+public interface VerificationSession {
+
+    /** Creates a verification session. */
+    static VerificationSession of(VerificationRequest request, AuthKey key) {
+        return ImmutableVerificationSession.builder()
+                .verificationRequest(request)
+                .authKey(key)
+                .build();
+    }
+
+    /** Creates a verification session for the verification request. */
+    static VerificationSession create(VerificationRequest request) {
+        AuthKey key = AuthKey.generate();
+        return of(request, key);
+    }
+
+    /** Deserializes the session from raw bytes. */
+    static VerificationSession deserialize(byte[] bytes) {
+        return SerializationUtils.deserialize(bytes, VerificationSession.class);
+    }
+
+    /** Verification request. */
+    VerificationRequest verificationRequest();
+
+    /** Ephemeral key used to encrypt any authentication data. */
+    AuthKey authKey();
+
+    /** Serializes the session to raw bytes. */
+    @Value.Lazy
+    @JsonIgnore
+    default byte[] serialize() {
+        return SerializationUtils.serialize(this);
+    }
+}

--- a/data/src/test/java/org/example/age/certificate/AgeCertificateTest.java
+++ b/data/src/test/java/org/example/age/certificate/AgeCertificateTest.java
@@ -70,6 +70,6 @@ public final class AgeCertificateTest {
 
     private static AgeCertificate createCertificate(VerificationRequest request) {
         VerifiedUser user = VerifiedUser.of(SecureId.generate(), 18);
-        return AgeCertificate.of(request, user);
+        return AgeCertificate.of(request, user, AuthToken.empty());
     }
 }

--- a/data/src/test/java/org/example/age/certificate/AuthTokenTest.java
+++ b/data/src/test/java/org/example/age/certificate/AuthTokenTest.java
@@ -1,6 +1,7 @@
 package org.example.age.certificate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.charset.StandardCharsets;
 import org.example.age.internal.SerializationUtils;
@@ -25,5 +26,19 @@ public final class AuthTokenTest {
         AuthToken deserializedToken = SerializationUtils.deserialize(bytes, AuthToken.class);
         byte[] decryptedData = deserializedToken.decrypt(key);
         assertThat(decryptedData).isEqualTo(DATA);
+    }
+
+    @Test
+    public void empty() {
+        AuthToken token = AuthToken.empty();
+        assertThat(token.isEmpty()).isTrue();
+    }
+
+    @Test
+    public void error_Decrypt_EmptyToken() {
+        AuthToken token = AuthToken.empty();
+        assertThatThrownBy(() -> token.decrypt(key))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("token is empty");
     }
 }

--- a/data/src/test/java/org/example/age/certificate/VerificationSessionTest.java
+++ b/data/src/test/java/org/example/age/certificate/VerificationSessionTest.java
@@ -1,0 +1,18 @@
+package org.example.age.certificate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+public final class VerificationSessionTest {
+
+    @Test
+    public void serializeThenDeserialize() {
+        VerificationRequest request = VerificationRequest.generateForSite("Site", Duration.ofMinutes(5));
+        VerificationSession session = VerificationSession.create(request);
+        byte[] bytes = session.serialize();
+        VerificationSession deserializedSession = VerificationSession.deserialize(bytes);
+        assertThat(deserializedSession).isEqualTo(session);
+    }
+}

--- a/verification-poc/src/main/java/org/example/age/verification/AvsVerificationComponent.java
+++ b/verification-poc/src/main/java/org/example/age/verification/AvsVerificationComponent.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.example.age.certificate.AgeCertificate;
+import org.example.age.certificate.AuthToken;
 import org.example.age.certificate.VerificationRequest;
 import org.example.age.data.AgeThresholds;
 import org.example.age.data.SecureId;
@@ -114,7 +115,7 @@ public final class AvsVerificationComponent implements AvsUi, AvsApi, VerifiedUs
     /** Creates an age certificate to verify an account on the site. */
     private AgeCertificate createAgeCertificateForSite(VerifiedUser user, VerificationRequest request, Site site) {
         VerifiedUser localUser = user.anonymizeAge(site.ageThresholds()).localize(site.remotePseudonymKey());
-        return AgeCertificate.of(request, localUser);
+        return AgeCertificate.of(request, localUser, AuthToken.empty());
     }
 
     /** Transmits an age certificate to the site. */

--- a/verification-poc/src/test/java/org/example/age/verification/SiteVerificationComponentTest.java
+++ b/verification-poc/src/test/java/org/example/age/verification/SiteVerificationComponentTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import org.assertj.core.api.ThrowableAssert;
 import org.example.age.certificate.AgeCertificate;
+import org.example.age.certificate.AuthToken;
 import org.example.age.certificate.VerificationRequest;
 import org.example.age.data.AgeRange;
 import org.example.age.data.SecureId;
@@ -190,7 +191,7 @@ public final class SiteVerificationComponentTest {
         public void processVerificationRequest(String realName, SecureId requestId) {
             VerificationRequest request = retrievePendingVerificationRequest(requestId);
             VerifiedUser user = retrieveVerifiedUser(realName);
-            AgeCertificate certificate = AgeCertificate.of(request, user);
+            AgeCertificate certificate = AgeCertificate.of(request, user, AuthToken.empty());
             byte[] signedCertificate = certificate.sign(signingKeyPair.getPrivate());
             siteApi.processAgeCertificate(signedCertificate);
         }


### PR DESCRIPTION
Example:
- 3rd-party service puts the IP address of the person who requested the age certificate in the token
- Site checks that the IP address of person verifying an account matches

Since the token may contain, e.g., an IP address, we encrypt authentication data with an ephemeral AES-256 key. The key is generated as part of the `VerificationSession`.