### PR TITLE
switch time format to epoch time

### DIFF
--- a/common/src/main/java/org/example/age/common/verification/VerificationState.java
+++ b/common/src/main/java/org/example/age/common/verification/VerificationState.java
@@ -1,7 +1,5 @@
 package org.example.age.common.verification;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import org.example.age.data.VerifiedUser;
 
 /** Current state for age verification. Some fields may be conditionally present based on the status. */
@@ -9,7 +7,7 @@ public final class VerificationState {
 
     private final VerificationStatus status;
     private final VerifiedUser verifiedUser;
-    private final ZonedDateTime expiration;
+    private final Long expiration;
 
     /** Creates an unverified state. */
     public static VerificationState unverified() {
@@ -17,12 +15,12 @@ public final class VerificationState {
     }
 
     /** Creates a verified state. */
-    public static VerificationState verified(VerifiedUser verifiedUser, ZonedDateTime expiration) {
+    public static VerificationState verified(VerifiedUser verifiedUser, long expiration) {
         return new VerificationState(VerificationStatus.VERIFIED, verifiedUser, expiration);
     }
 
     /** Creates an expired state. */
-    public static VerificationState expired(ZonedDateTime expiration) {
+    public static VerificationState expired(long expiration) {
         return new VerificationState(VerificationStatus.EXPIRED, null, expiration);
     }
 
@@ -41,8 +39,8 @@ public final class VerificationState {
         return checkAttributeSet(verifiedUser);
     }
 
-    /** Gets the time when the user's verified status expired or will expire. */
-    public ZonedDateTime expiration() {
+    /** Gets the epoch time when the user's verified status expired or will expire. */
+    public long expiration() {
         return checkAttributeSet(expiration);
     }
 
@@ -52,8 +50,8 @@ public final class VerificationState {
             return this;
         }
 
-        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
-        if (now.isBefore(expiration)) {
+        long now = System.currentTimeMillis() / 1000;
+        if (now < expiration) {
             return this;
         }
 
@@ -70,7 +68,7 @@ public final class VerificationState {
         return attribute;
     }
 
-    private VerificationState(VerificationStatus status, VerifiedUser verifiedUser, ZonedDateTime expiration) {
+    private VerificationState(VerificationStatus status, VerifiedUser verifiedUser, Long expiration) {
         this.status = status;
         this.verifiedUser = verifiedUser;
         this.expiration = expiration;

--- a/common/src/test/java/org/example/age/common/verification/VerificationStateTest.java
+++ b/common/src/test/java/org/example/age/common/verification/VerificationStateTest.java
@@ -3,9 +3,6 @@ package org.example.age.common.verification;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.time.Duration;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import org.assertj.core.api.ThrowableAssert;
 import org.example.age.data.SecureId;
 import org.example.age.data.VerifiedUser;
@@ -14,7 +11,7 @@ import org.junit.jupiter.api.Test;
 public final class VerificationStateTest {
 
     private static final VerifiedUser VERIFIED_USER = VerifiedUser.of(SecureId.generate(), 18);
-    private static final ZonedDateTime EXPIRATION = ZonedDateTime.now(ZoneOffset.UTC);
+    private static final long EXPIRATION = System.currentTimeMillis() / 1000;
 
     @Test
     public void unverified() {
@@ -52,7 +49,7 @@ public final class VerificationStateTest {
 
     @Test
     public void update_VerifiedAndNotExpired() {
-        ZonedDateTime future = ZonedDateTime.now(ZoneOffset.UTC).plus(Duration.ofMinutes(5));
+        long future = EXPIRATION + 10;
         VerificationState state = VerificationState.verified(VERIFIED_USER, future);
         VerificationState updatedState = state.update();
         assertThat(updatedState).isSameAs(state);
@@ -60,7 +57,7 @@ public final class VerificationStateTest {
 
     @Test
     public void update_VerifiedButExpired() {
-        ZonedDateTime past = ZonedDateTime.now(ZoneOffset.UTC).minus(Duration.ofMinutes(5));
+        long past = EXPIRATION - 10;
         VerificationState state = VerificationState.verified(VERIFIED_USER, past);
         VerificationState updatedState = state.update();
         assertThat(updatedState.status()).isEqualTo(VerificationStatus.EXPIRED);

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -9,7 +9,6 @@ dependencies {
 
     implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-guava:2.15.2")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2")
     implementation("com.google.guava:guava:32.1.1-jre")
 
     testImplementation(project(":testing"))

--- a/data/src/main/java/org/example/age/internal/SerializationUtils.java
+++ b/data/src/main/java/org/example/age/internal/SerializationUtils.java
@@ -3,7 +3,6 @@ package org.example.age.internal;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
 
 /** Utilities for serializing and deserializing objects to and from bytes. */
@@ -39,7 +38,6 @@ public final class SerializationUtils {
     /** Creates a mapper for serialization and deserialization. */
     private static ObjectMapper createMapper() {
         ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
         mapper.registerModule(new GuavaModule());
         return mapper;
     }

--- a/data/src/test/java/org/example/age/certificate/VerificationRequestTest.java
+++ b/data/src/test/java/org/example/age/certificate/VerificationRequestTest.java
@@ -3,10 +3,7 @@ package org.example.age.certificate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
-import org.assertj.core.data.TemporalUnitWithinOffset;
+import org.assertj.core.data.Offset;
 import org.example.age.internal.SerializationUtils;
 import org.junit.jupiter.api.Test;
 
@@ -20,9 +17,9 @@ public final class VerificationRequestTest {
         VerificationRequest request = VerificationRequest.generateForSite(SITE_ID, EXPIRES_IN);
         assertThat(request.id()).isNotNull();
         assertThat(request.siteId()).isEqualTo(SITE_ID);
-        ZonedDateTime now = ZonedDateTime.now(ZoneId.systemDefault());
-        assertThat(request.expiration())
-                .isCloseTo(now.plus(EXPIRES_IN), new TemporalUnitWithinOffset(1, ChronoUnit.SECONDS));
+        long now = System.currentTimeMillis() / 1000;
+        long expectedExpiration = now + EXPIRES_IN.toSeconds();
+        assertThat(request.expiration()).isCloseTo(expectedExpiration, Offset.offset(1L));
     }
 
     @Test

--- a/demo/src/main/java/org/example/age/demo/Main.java
+++ b/demo/src/main/java/org/example/age/demo/Main.java
@@ -1,6 +1,7 @@
 package org.example.age.demo;
 
 import com.google.errorprone.annotations.FormatMethod;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -141,7 +142,7 @@ public final class Main {
         String siteName = siteUi.getName();
 
         println("Detailed workflow to verify \"%s\" on %s:", username, siteName);
-        println("- The current time is %s.", time(ZonedDateTime.now(ZoneId.systemDefault())));
+        println("- The current time is %s.", time(System.currentTimeMillis() / 1000));
         println("- [#1], [#2] is used to denote when data is stored that will be used later.");
         println();
         println("For a proof-of-concept, everything runs on a single machine;");
@@ -250,10 +251,10 @@ public final class Main {
         return String.format("%s...", idText.substring(0, 8));
     }
 
-    /** Formats a time. */
-    private static String time(ZonedDateTime dateTime) {
-        ZonedDateTime localExpiration = dateTime.withZoneSameInstant(ZoneId.systemDefault());
-        return localExpiration.format(DateTimeFormatter.ofPattern("LLLL d, yyyy, h:mm:ss a z"));
+    /** Formats an epoch time. */
+    private static String time(long epoch) {
+        ZonedDateTime localTime = ZonedDateTime.ofInstant(Instant.ofEpochSecond(epoch), ZoneId.systemDefault());
+        return localTime.format(DateTimeFormatter.ofPattern("LLLL d, yyyy, h:mm:ss a z"));
     }
 
     /** Displays a border. */


### PR DESCRIPTION
avoids potential issue in naive implementations where timezone leaks location information