### PR TITLE
add simplified verification store interface, in-memory implementation

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
 
     implementation(project(":data"))
     implementation("com.google.dagger:dagger:2.47")
+    implementation("com.google.guava:guava:32.1.1-jre")
     implementation("com.squareup.okhttp3:okhttp:4.11.0")
     implementation("io.undertow:undertow-core:2.3.8.Final")
     implementation("javax.inject:javax.inject:1")

--- a/common/src/main/java/org/example/age/common/verification/InMemoryVerificationStore.java
+++ b/common/src/main/java/org/example/age/common/verification/InMemoryVerificationStore.java
@@ -1,0 +1,86 @@
+package org.example.age.common.verification;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import javax.inject.Inject;
+import org.example.age.data.SecureId;
+import org.example.age.data.VerifiedUser;
+
+/** In-memory {@link VerificationStore}. */
+final class InMemoryVerificationStore implements VerificationStore {
+
+    private final Map<String, VerificationState> states = new HashMap<>();
+    private final BiMap<SecureId, String> verifiedAccountIds = HashBiMap.create();
+
+    private final Object lock = new Object();
+
+    @Inject
+    public InMemoryVerificationStore() {}
+
+    @Override
+    public VerificationState load(String accountId) {
+        VerificationState updatedState;
+        synchronized (lock) {
+            Optional<VerificationState> maybeState = Optional.ofNullable(states.get(accountId));
+            if (maybeState.isEmpty()) {
+                return VerificationState.unverified();
+            }
+
+            VerificationState state = maybeState.get();
+            updatedState = state.update();
+            if (updatedState != state) {
+                save(accountId, updatedState);
+            }
+        }
+        return updatedState;
+    }
+
+    @Override
+    public Optional<String> trySave(String accountId, VerificationState state) {
+        synchronized (lock) {
+            Optional<String> maybeDuplicateAccountId = checkNoDuplicateVerifications(accountId, state);
+            if (maybeDuplicateAccountId.isPresent()) {
+                return maybeDuplicateAccountId;
+            }
+
+            save(accountId, state);
+        }
+        return Optional.empty();
+    }
+
+    /** Checks that two accounts are not verified with the same {@link VerifiedUser}. */
+    private Optional<String> checkNoDuplicateVerifications(String accountId, VerificationState state) {
+        if (state.status() != VerificationStatus.VERIFIED) {
+            return Optional.empty();
+        }
+
+        SecureId pseudonym = state.verifiedUser().pseudonym();
+        Optional<String> maybeVerifiedAccountId = Optional.ofNullable(verifiedAccountIds.get(pseudonym));
+        if (maybeVerifiedAccountId.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String verifiedAccountId = maybeVerifiedAccountId.get();
+        if (verifiedAccountId.equals(accountId)) {
+            return Optional.empty();
+        }
+
+        VerificationState otherState = load(verifiedAccountId);
+        return (otherState.status() == VerificationStatus.VERIFIED) ? Optional.of(verifiedAccountId) : Optional.empty();
+    }
+
+    /** Saves the {@link VerificationState} for an account. */
+    private void save(String accountId, VerificationState state) {
+        states.put(accountId, state);
+        if (state.status() != VerificationStatus.VERIFIED) {
+            verifiedAccountIds.inverse().remove(accountId);
+            return;
+        }
+
+        SecureId pseudonym = state.verifiedUser().pseudonym();
+        verifiedAccountIds.put(pseudonym, accountId);
+    }
+}

--- a/common/src/main/java/org/example/age/common/verification/InMemoryVerificationStoreModule.java
+++ b/common/src/main/java/org/example/age/common/verification/InMemoryVerificationStoreModule.java
@@ -1,0 +1,12 @@
+package org.example.age.common.verification;
+
+import dagger.Binds;
+import dagger.Module;
+
+/** Dagger module that publishes a binding for {@link VerificationStore}, which uses an in-memory store. */
+@Module
+public interface InMemoryVerificationStoreModule {
+
+    @Binds
+    VerificationStore bindVerificationStateStore(InMemoryVerificationStore impl);
+}

--- a/common/src/main/java/org/example/age/common/verification/VerificationStore.java
+++ b/common/src/main/java/org/example/age/common/verification/VerificationStore.java
@@ -1,0 +1,20 @@
+package org.example.age.common.verification;
+
+import java.util.Optional;
+
+/**
+ * Stores {@link VerificationState}'s for accounts.
+ *
+ * <p>The account ID could be a username, or it could be an ephemeral ID for a session.</p>
+ */
+public interface VerificationStore {
+
+    /** Loads the {@link VerificationState} for the account. */
+    VerificationState load(String accountId);
+
+    /**
+     * Saves the {@link VerificationState} for the account, unless a duplicate verification occurs.
+     * Returns the account ID that is already verified if a duplicate verification occurs.
+     */
+    Optional<String> trySave(String accountId, VerificationState state);
+}

--- a/common/src/test/java/org/example/age/common/verification/InMemoryVerificationStoreTest.java
+++ b/common/src/test/java/org/example/age/common/verification/InMemoryVerificationStoreTest.java
@@ -1,0 +1,103 @@
+package org.example.age.common.verification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dagger.Component;
+import java.util.Optional;
+import javax.inject.Singleton;
+import org.example.age.data.SecureId;
+import org.example.age.data.VerifiedUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public final class InMemoryVerificationStoreTest {
+
+    private VerificationStore verificationStore;
+
+    @BeforeEach
+    public void createVerificationStore() {
+        verificationStore = TestComponent.createVerificationStore();
+    }
+
+    @Test
+    public void loadUnverified() {
+        VerificationState state = verificationStore.load("username");
+        assertThat(state.status()).isEqualTo(VerificationStatus.UNVERIFIED);
+    }
+
+    @Test
+    public void saveAndLoad() {
+        VerificationState state = createVerifiedState();
+        Optional<String> maybeDuplicateAccountId = verificationStore.trySave("username", state);
+        assertThat(maybeDuplicateAccountId).isEmpty();
+        VerificationState loadedState = verificationStore.load("username");
+        assertThat(loadedState.status()).isEqualTo(VerificationStatus.VERIFIED);
+    }
+
+    @Test
+    public void saveTwiceForSameAccount() {
+        VerificationState state = createVerifiedState();
+        verificationStore.trySave("username", state);
+
+        Optional<String> maybeDuplicateAccountId = verificationStore.trySave("username", state);
+        assertThat(maybeDuplicateAccountId).isEmpty();
+    }
+
+    @Test
+    public void saveUpdateAndLoad() {
+        long past = (System.currentTimeMillis() / 1000) - 10;
+        VerificationState state = createVerifiedState(past);
+        verificationStore.trySave("username", state);
+        VerificationState loadedState = verificationStore.load("username");
+        assertThat(loadedState.status()).isEqualTo(VerificationStatus.EXPIRED);
+    }
+
+    @Test
+    public void switchVerifiedAccount() {
+        VerificationState state = createVerifiedState();
+        verificationStore.trySave("username1", state);
+
+        verificationStore.trySave("username1", VerificationState.invalidated());
+        VerificationState loadedState1 = verificationStore.load("username1");
+        assertThat(loadedState1.status()).isEqualTo(VerificationStatus.INVALIDATED);
+
+        Optional<String> maybeDuplicateAccountId = verificationStore.trySave("username2", state);
+        assertThat(maybeDuplicateAccountId).isEmpty();
+        VerificationState loadedState2 = verificationStore.load("username2");
+        assertThat(loadedState2.status()).isEqualTo(VerificationStatus.VERIFIED);
+    }
+
+    @Test
+    public void failToSaveDuplicateVerification() {
+        VerificationState state = createVerifiedState();
+        verificationStore.trySave("username1", state);
+
+        Optional<String> maybeDuplicateAccountId = verificationStore.trySave("username2", state);
+        assertThat(maybeDuplicateAccountId).hasValue("username1");
+        VerificationState loadedState = verificationStore.load("username2");
+        assertThat(loadedState.status()).isEqualTo(VerificationStatus.UNVERIFIED);
+    }
+
+    private static VerificationState createVerifiedState() {
+        long future = (System.currentTimeMillis() / 1000) + 10;
+        return createVerifiedState(future);
+    }
+
+    private static VerificationState createVerifiedState(long expiration) {
+        VerifiedUser user = VerifiedUser.of(SecureId.generate(), 18);
+        return VerificationState.verified(user, expiration);
+    }
+
+    /** Dagger component that provides a {@link VerificationStore}. */
+    @Component(modules = InMemoryVerificationStoreModule.class)
+    @Singleton
+    interface TestComponent {
+
+        static VerificationStore createVerificationStore() {
+            TestComponent component = DaggerInMemoryVerificationStoreTest_TestComponent.create();
+            return component.verificationStore();
+        }
+
+        VerificationStore verificationStore();
+    }
+}


### PR DESCRIPTION
- only has `load()`, `trySave()`
- push out extracting account ID from HTTP exchange
- add in duplicate verification check