### PR TITLE
more Sender infra

### DIFF
--- a/common-api/src/main/java/org/example/age/common/api/CodeSender.java
+++ b/common-api/src/main/java/org/example/age/common/api/CodeSender.java
@@ -15,5 +15,10 @@ public interface CodeSender extends Sender {
         send(StatusCodes.OK);
     }
 
+    @Override
+    default void sendError(int statusCode) {
+        send(statusCode);
+    }
+
     void send(int statusCode);
 }

--- a/common-api/src/main/java/org/example/age/common/api/JsonSender.java
+++ b/common-api/src/main/java/org/example/age/common/api/JsonSender.java
@@ -5,19 +5,20 @@ import io.undertow.server.HttpServerExchange;
 
 /** Response sender that sends a JSON body, or an error status code. */
 @FunctionalInterface
-public interface JsonSender<T> extends Sender {
+public interface JsonSender<B> extends Sender {
 
-    static <T> JsonSender<T> create(HttpServerExchange exchange, ObjectMapper mapper) {
+    static <B> JsonSender<B> create(HttpServerExchange exchange, ObjectMapper mapper) {
         return new JsonSenderImpl<>(exchange, mapper);
     }
 
-    default void sendBody(T body) {
+    default void sendBody(B body) {
         send(HttpOptional.of(body));
     }
 
+    @Override
     default void sendError(int statusCode) {
         send(HttpOptional.empty(statusCode));
     }
 
-    void send(HttpOptional<T> maybeBody);
+    void send(HttpOptional<B> maybeBody);
 }

--- a/common-api/src/main/java/org/example/age/common/api/Sender.java
+++ b/common-api/src/main/java/org/example/age/common/api/Sender.java
@@ -1,4 +1,12 @@
 package org.example.age.common.api;
 
-/** Response sender. */
-public interface Sender {}
+/**
+ * Response sender that sends an error status code.
+ *
+ * <p>Sub-interfaces will specify how to send to a successful response.</p>
+ */
+@FunctionalInterface
+public interface Sender {
+
+    void sendError(int statusCode);
+}

--- a/common-service/pom.xml
+++ b/common-service/pom.xml
@@ -48,6 +48,12 @@
             <version>${revision}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.example.age</groupId>
+            <artifactId>testing-service</artifactId>
+            <version>${revision}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/common-service/src/test/java/org/example/age/common/service/data/auth/UserAgentAuthMatchDataExtractorTest.java
+++ b/common-service/src/test/java/org/example/age/common/service/data/auth/UserAgentAuthMatchDataExtractorTest.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import javax.inject.Singleton;
 import org.example.age.common.api.data.auth.AuthMatchDataExtractor;
 import org.example.age.data.certificate.AuthKey;
-import org.example.age.testing.client.TestExchanges;
+import org.example.age.testing.exchange.TestExchanges;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 

--- a/common/src/test/java/org/example/age/common/avs/verification/VerificationManagerTest.java
+++ b/common/src/test/java/org/example/age/common/avs/verification/VerificationManagerTest.java
@@ -28,7 +28,7 @@ import org.example.age.data.AgeThresholds;
 import org.example.age.data.SecureId;
 import org.example.age.data.VerifiedUser;
 import org.example.age.data.certificate.VerificationSession;
-import org.example.age.testing.client.TestExchanges;
+import org.example.age.testing.exchange.TestExchanges;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/src/test/java/org/example/age/common/base/client/internal/ExchangeClientImplTest.java
+++ b/common/src/test/java/org/example/age/common/base/client/internal/ExchangeClientImplTest.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.mock;
 
 import io.undertow.server.HttpServerExchange;
 import okhttp3.OkHttpClient;
-import org.example.age.testing.client.TestExchanges;
+import org.example.age.testing.exchange.TestExchanges;
 import org.junit.jupiter.api.Test;
 
 public final class ExchangeClientImplTest {

--- a/common/src/test/java/org/example/age/common/base/utils/internal/PendingStoreUtilsTest.java
+++ b/common/src/test/java/org/example/age/common/base/utils/internal/PendingStoreUtilsTest.java
@@ -12,7 +12,7 @@ import org.example.age.common.base.store.PendingStore;
 import org.example.age.common.base.store.PendingStoreFactory;
 import org.example.age.data.certificate.VerificationRequest;
 import org.example.age.data.certificate.VerificationSession;
-import org.example.age.testing.client.TestExchanges;
+import org.example.age.testing.exchange.TestExchanges;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/common/src/test/java/org/example/age/common/site/auth/internal/AuthManagerTest.java
+++ b/common/src/test/java/org/example/age/common/site/auth/internal/AuthManagerTest.java
@@ -22,7 +22,7 @@ import org.example.age.data.certificate.AuthKey;
 import org.example.age.data.certificate.AuthToken;
 import org.example.age.data.certificate.VerificationRequest;
 import org.example.age.data.certificate.VerificationSession;
-import org.example.age.testing.client.TestExchanges;
+import org.example.age.testing.exchange.TestExchanges;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/src/test/java/org/example/age/common/site/verification/internal/VerificationManagerTest.java
+++ b/common/src/test/java/org/example/age/common/site/verification/internal/VerificationManagerTest.java
@@ -24,7 +24,7 @@ import org.example.age.data.certificate.AuthKey;
 import org.example.age.data.certificate.AuthToken;
 import org.example.age.data.certificate.VerificationRequest;
 import org.example.age.data.certificate.VerificationSession;
-import org.example.age.testing.client.TestExchanges;
+import org.example.age.testing.exchange.TestExchanges;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/testing-server/pom.xml
+++ b/testing-server/pom.xml
@@ -51,19 +51,9 @@
             <version>1</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.xnio</groupId>
-            <artifactId>xnio-api</artifactId>
-            <version>${xnio.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${junit-jupiter.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
         </dependency>
     </dependencies>
 
@@ -79,11 +69,6 @@
                             <groupId>com.google.dagger</groupId>
                             <artifactId>dagger-compiler</artifactId>
                             <version>${dagger.version}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.immutables</groupId>
-                            <artifactId>value</artifactId>
-                            <version>${immutables.version}</version>
                         </dependency>
                     </annotationProcessorPaths>
                 </configuration>

--- a/testing-service/pom.xml
+++ b/testing-service/pom.xml
@@ -35,20 +35,15 @@
             <artifactId>javax.inject</artifactId>
             <version>1</version>
         </dependency>
-
-        <!-- test -->
         <dependency>
-            <groupId>org.example.age</groupId>
-            <artifactId>testing-server</artifactId>
-            <version>${revision}</version>
-            <scope>test</scope>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-api</artifactId>
+            <version>${xnio.version}</version>
         </dependency>
-
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
-            <scope>test</scope>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
         </dependency>
     </dependencies>
 

--- a/testing-service/src/main/java/org/example/age/testing/exchange/TestExchanges.java
+++ b/testing-service/src/main/java/org/example/age/testing/exchange/TestExchanges.java
@@ -1,4 +1,4 @@
-package org.example.age.testing.client;
+package org.example.age.testing.exchange;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -14,7 +14,7 @@ import org.xnio.XnioExecutor;
 import org.xnio.XnioIoThread;
 import org.xnio.XnioWorker;
 
-/** Creates {@link HttpServerExchange}'s for testing. */
+/** Creates stub {@link HttpServerExchange}'s. */
 public final class TestExchanges {
 
     /**

--- a/testing-service/src/main/java/org/example/age/testing/service/TestCodeSender.java
+++ b/testing-service/src/main/java/org/example/age/testing/service/TestCodeSender.java
@@ -1,0 +1,41 @@
+package org.example.age.testing.service;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.example.age.common.api.CodeSender;
+
+/** Fake {@link CodeSender} that stores the status code that was sent. */
+public final class TestCodeSender implements CodeSender {
+
+    private int statusCode;
+    private AtomicBoolean wasSent = new AtomicBoolean(false);
+
+    /** Creates a {@link TestCodeSender}. */
+    public static TestCodeSender create() {
+        return new TestCodeSender();
+    }
+
+    /** Determines if a response was sent. */
+    public boolean wasSent() {
+        return wasSent.get();
+    }
+
+    /** Gets the status code that was sent. */
+    public int get() {
+        if (!wasSent.get()) {
+            throw new IllegalStateException("response has not been sent");
+        }
+
+        return statusCode;
+    }
+
+    @Override
+    public void send(int statusCode) {
+        if (wasSent.getAndSet(true)) {
+            throw new IllegalStateException("response was already sent");
+        }
+
+        this.statusCode = statusCode;
+    }
+
+    private TestCodeSender() {}
+}

--- a/testing-service/src/main/java/org/example/age/testing/service/TestJsonSender.java
+++ b/testing-service/src/main/java/org/example/age/testing/service/TestJsonSender.java
@@ -1,0 +1,42 @@
+package org.example.age.testing.service;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.example.age.common.api.HttpOptional;
+import org.example.age.common.api.JsonSender;
+
+/** Fake {@link JsonSender} that stores the body (or error status code) that was sent. */
+public final class TestJsonSender<B> implements JsonSender<B> {
+
+    private HttpOptional<B> maybeBody;
+    private AtomicBoolean wasSent = new AtomicBoolean(false);
+
+    /** Creates a {@link TestJsonSender}. */
+    public static TestJsonSender create() {
+        return new TestJsonSender();
+    }
+
+    /** Determines if a response was sent. */
+    public boolean wasSent() {
+        return wasSent.get();
+    }
+
+    /** Gets the body (or error status code) that was sent. */
+    public HttpOptional<B> get() {
+        if (!wasSent.get()) {
+            throw new IllegalStateException("response has not been sent");
+        }
+
+        return maybeBody;
+    }
+
+    @Override
+    public void send(HttpOptional maybeBody) {
+        if (wasSent.getAndSet(true)) {
+            throw new IllegalStateException("response was already sent");
+        }
+
+        this.maybeBody = maybeBody;
+    }
+
+    private TestJsonSender() {}
+}

--- a/testing-service/src/test/java/org/example/age/testing/exchange/TestExchangesTest.java
+++ b/testing-service/src/test/java/org/example/age/testing/exchange/TestExchangesTest.java
@@ -1,4 +1,4 @@
-package org.example.age.testing.client;
+package org.example.age.testing.exchange;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;

--- a/testing-service/src/test/java/org/example/age/testing/service/TestCodeSenderTest.java
+++ b/testing-service/src/test/java/org/example/age/testing/service/TestCodeSenderTest.java
@@ -1,0 +1,41 @@
+package org.example.age.testing.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.undertow.util.StatusCodes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public final class TestCodeSenderTest {
+
+    private TestCodeSender sender;
+
+    @BeforeEach
+    public void createCodeSender() {
+        sender = TestCodeSender.create();
+    }
+
+    @Test
+    public void sendAndGet() {
+        assertThat(sender.wasSent()).isFalse();
+        sender.sendError(StatusCodes.FORBIDDEN);
+        assertThat(sender.wasSent()).isTrue();
+        assertThat(sender.get()).isEqualTo(403);
+    }
+
+    @Test
+    public void error_GetWithoutSend() {
+        assertThatThrownBy(sender::get)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("response has not been sent");
+    }
+
+    @Test
+    public void error_SendTwice() {
+        sender.sendError(StatusCodes.FORBIDDEN);
+        assertThatThrownBy(() -> sender.sendError(StatusCodes.OK))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("response was already sent");
+    }
+}

--- a/testing-service/src/test/java/org/example/age/testing/service/TestJsonSenderTest.java
+++ b/testing-service/src/test/java/org/example/age/testing/service/TestJsonSenderTest.java
@@ -1,0 +1,41 @@
+package org.example.age.testing.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.example.age.common.api.HttpOptional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public final class TestJsonSenderTest {
+
+    private TestJsonSender<String> sender;
+
+    @BeforeEach
+    public void createJsonSender() {
+        sender = TestJsonSender.create();
+    }
+
+    @Test
+    public void sendAndGet() {
+        assertThat(sender.wasSent()).isFalse();
+        sender.sendBody("test");
+        assertThat(sender.wasSent()).isTrue();
+        assertThat(sender.get()).isEqualTo(HttpOptional.of("test"));
+    }
+
+    @Test
+    public void error_GetWithoutSend() {
+        assertThatThrownBy(sender::get)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("response has not been sent");
+    }
+
+    @Test
+    public void error_SendTwice() {
+        sender.sendBody("test");
+        assertThatThrownBy(() -> sender.sendBody("test"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("response was already sent");
+    }
+}

--- a/testing-service/src/test/java/org/example/age/testing/service/data/account/TestAccountIdExtractorTest.java
+++ b/testing-service/src/test/java/org/example/age/testing/service/data/account/TestAccountIdExtractorTest.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.Optional;
 import javax.inject.Singleton;
 import org.example.age.common.api.data.account.AccountIdExtractor;
-import org.example.age.testing.client.TestExchanges;
+import org.example.age.testing.exchange.TestExchanges;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
- add `sendError()` to base `Sender` interface
    - lets infra send an error w/o knowing the type of response that is sent
 - add fakes for `CodeSender`, `JsonSender`
 - also pull `TestExchanges` into `testing-service`
   - fakes/stubs go in `testing-service`
   - E2E client/server infra goes in `testing-server` 