### PR TITLE
move (new) API infra into infra-api module

### DIFF
--- a/avs-api/pom.xml
+++ b/avs-api/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>data</artifactId>
             <version>${revision}</version>
         </dependency>
+        <dependency>
+            <groupId>org.example.age</groupId>
+            <artifactId>infra-api</artifactId>
+            <version>${revision}</version>
+        </dependency>
 
         <dependency>
             <groupId>com.google.dagger</groupId>

--- a/avs-api/src/main/java/module-info.java
+++ b/avs-api/src/main/java/module-info.java
@@ -8,5 +8,6 @@ module org.example.age.avs.api {
     requires org.example.age.api;
     requires org.example.age.common.api;
     requires org.example.age.data;
+    requires org.example.age.infra.api;
     requires undertow.core;
 }

--- a/avs-api/src/main/java/org/example/age/avs/api/AvsEndpointHandler.java
+++ b/avs-api/src/main/java/org/example/age/avs/api/AvsEndpointHandler.java
@@ -11,16 +11,16 @@ import javax.inject.Singleton;
 import org.example.age.api.CodeSender;
 import org.example.age.api.Dispatcher;
 import org.example.age.api.JsonSender;
-import org.example.age.common.api.ExchangeCodeSender;
-import org.example.age.common.api.ExchangeDispatcher;
-import org.example.age.common.api.ExchangeJsonSender;
 import org.example.age.common.api.data.account.AccountIdExtractor;
 import org.example.age.common.api.data.auth.AuthMatchData;
 import org.example.age.common.api.data.auth.AuthMatchDataExtractor;
-import org.example.age.common.api.request.impl.RequestParser;
 import org.example.age.data.DataMapper;
 import org.example.age.data.SecureId;
 import org.example.age.data.certificate.VerificationSession;
+import org.example.age.infra.api.ExchangeCodeSender;
+import org.example.age.infra.api.ExchangeDispatcher;
+import org.example.age.infra.api.ExchangeJsonSender;
+import org.example.age.infra.api.request.RequestParser;
 
 @Singleton
 final class AvsEndpointHandler implements HttpHandler {

--- a/common-api/src/main/java/module-info.java
+++ b/common-api/src/main/java/module-info.java
@@ -1,13 +1,9 @@
 module org.example.age.common.api {
-    exports org.example.age.common.api;
     exports org.example.age.common.api.data.auth;
     exports org.example.age.common.api.data.account;
     exports org.example.age.common.api.exchange.impl;
-    exports org.example.age.common.api.request.impl;
 
-    requires com.fasterxml.jackson.databind;
     requires org.example.age.api;
     requires org.example.age.data;
     requires undertow.core;
-    requires xnio.api;
 }

--- a/infra-api/pom.xml
+++ b/infra-api/pom.xml
@@ -9,7 +9,7 @@
         <artifactId>age-verification</artifactId>
         <version>${revision}</version>
     </parent>
-    <artifactId>common-api</artifactId>
+    <artifactId>infra-api</artifactId>
     <packaging>jar</packaging>
 
     <dependencies>
@@ -19,16 +19,21 @@
             <artifactId>api</artifactId>
             <version>${revision}</version>
         </dependency>
-        <dependency>
-            <groupId>org.example.age</groupId>
-            <artifactId>data</artifactId>
-            <version>${revision}</version>
-        </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-core</artifactId>
             <version>${undertow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-api</artifactId>
+            <version>${xnio.version}</version>
         </dependency>
 
         <!-- test -->

--- a/infra-api/src/main/java/module-info.java
+++ b/infra-api/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module org.example.age.infra.api {
+    exports org.example.age.infra.api;
+    exports org.example.age.infra.api.request;
+
+    requires com.fasterxml.jackson.databind;
+    requires org.example.age.api;
+    requires undertow.core;
+    requires xnio.api;
+}

--- a/infra-api/src/main/java/org/example/age/infra/api/ExchangeCodeSender.java
+++ b/infra-api/src/main/java/org/example/age/infra/api/ExchangeCodeSender.java
@@ -1,4 +1,4 @@
-package org.example.age.common.api;
+package org.example.age.infra.api;
 
 import io.undertow.server.HttpServerExchange;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/infra-api/src/main/java/org/example/age/infra/api/ExchangeDispatcher.java
+++ b/infra-api/src/main/java/org/example/age/infra/api/ExchangeDispatcher.java
@@ -1,4 +1,4 @@
-package org.example.age.common.api;
+package org.example.age.infra.api;
 
 import io.undertow.server.Connectors;
 import io.undertow.server.HttpServerExchange;

--- a/infra-api/src/main/java/org/example/age/infra/api/ExchangeJsonSender.java
+++ b/infra-api/src/main/java/org/example/age/infra/api/ExchangeJsonSender.java
@@ -1,4 +1,4 @@
-package org.example.age.common.api;
+package org.example.age.infra.api;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/infra-api/src/main/java/org/example/age/infra/api/request/RequestJsonCallback.java
+++ b/infra-api/src/main/java/org/example/age/infra/api/request/RequestJsonCallback.java
@@ -1,4 +1,4 @@
-package org.example.age.common.api.request.impl;
+package org.example.age.infra.api.request;
 
 import io.undertow.server.HttpServerExchange;
 

--- a/infra-api/src/main/java/org/example/age/infra/api/request/RequestParser.java
+++ b/infra-api/src/main/java/org/example/age/infra/api/request/RequestParser.java
@@ -1,4 +1,4 @@
-package org.example.age.common.api.request.impl;
+package org.example.age.infra.api.request;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/infra-api/src/test/java/org/example/age/infra/api/ExchangeCodeSenderTest.java
+++ b/infra-api/src/test/java/org/example/age/infra/api/ExchangeCodeSenderTest.java
@@ -1,4 +1,4 @@
-package org.example.age.common.api;
+package org.example.age.infra.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/infra-api/src/test/java/org/example/age/infra/api/ExchangeDispatcherTest.java
+++ b/infra-api/src/test/java/org/example/age/infra/api/ExchangeDispatcherTest.java
@@ -1,4 +1,4 @@
-package org.example.age.common.api;
+package org.example.age.infra.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/infra-api/src/test/java/org/example/age/infra/api/ExchangeJsonSenderTest.java
+++ b/infra-api/src/test/java/org/example/age/infra/api/ExchangeJsonSenderTest.java
@@ -1,4 +1,4 @@
-package org.example.age.common.api;
+package org.example.age.infra.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/infra-api/src/test/java/org/example/age/infra/api/request/RequestParserTest.java
+++ b/infra-api/src/test/java/org/example/age/infra/api/request/RequestParserTest.java
@@ -1,4 +1,4 @@
-package org.example.age.common.api.request.impl;
+package org.example.age.infra.api.request;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,7 +13,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.example.age.api.JsonSender;
-import org.example.age.common.api.ExchangeJsonSender;
+import org.example.age.infra.api.ExchangeJsonSender;
 import org.example.age.testing.client.TestClient;
 import org.example.age.testing.server.TestUndertowServer;
 import org.junit.jupiter.api.Test;

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <module>common-service</module>
         <module>data</module>
         <module>demo</module>
+        <module>infra-api</module>
         <module>testing</module>
         <module>testing-server</module>
         <module>testing-service</module>


### PR DESCRIPTION
- only `*-api` will depend on `infra-api`
- `*-service` can still depend on `*-api` (not including `infra-api`)