### PR TITLE
add method to sign age certificates

### DIFF
--- a/data/src/main/java/org/example/age/data/certificate/DigitalSignature.java
+++ b/data/src/main/java/org/example/age/data/certificate/DigitalSignature.java
@@ -10,26 +10,30 @@ import org.example.age.data.DataMapper;
 import org.example.age.data.internal.ImmutableBytes;
 import org.example.age.data.internal.StaticFromStringDeserializer;
 
-/** Signature used to verify the sender's identity. */
+/**
+ * Signature used to verify the sender's identity.
+ *
+ * <p>The value to sign must be serializable using {@link DataMapper}.</p>
+ */
 @JsonSerialize(using = ToStringSerializer.class)
 @JsonDeserialize(using = DigitalSignature.Deserializer.class)
 public final class DigitalSignature extends ImmutableBytes {
 
-    /** Creates a signature for the value. */
-    public static DigitalSignature create(Object value, PrivateKey privateKey) {
-        byte[] rawValue = serialize(value);
-        byte[] rawSignature = SignatureUtils.sign(rawValue, privateKey);
-        return ofBytes(rawSignature);
-    }
-
     /** Creates a signature from a copy of the raw bytes. */
-    public static DigitalSignature ofBytes(byte[] bytes) {
-        return new DigitalSignature(bytes);
+    public static DigitalSignature ofBytes(byte[] rawSignature) {
+        return new DigitalSignature(rawSignature);
     }
 
     /** Creates a signature from URL-friendly base64 text. */
-    public static DigitalSignature fromString(String value) {
-        return new DigitalSignature(value);
+    public static DigitalSignature fromString(String rawSignature) {
+        return new DigitalSignature(rawSignature);
+    }
+
+    /** Signs the value. */
+    public static DigitalSignature sign(Object value, PrivateKey privateKey) {
+        byte[] rawValue = serialize(value);
+        byte[] rawSignature = SignatureUtils.sign(rawValue, privateKey);
+        return ofBytes(rawSignature);
     }
 
     /** Verifies the signature against the value, returning whether verification succeeded. */
@@ -38,12 +42,12 @@ public final class DigitalSignature extends ImmutableBytes {
         return SignatureUtils.verify(rawValue, bytes, publicKey);
     }
 
-    private DigitalSignature(byte[] bytes) {
-        super(bytes);
+    private DigitalSignature(byte[] rawSignature) {
+        super(rawSignature);
     }
 
-    private DigitalSignature(String value) {
-        super(value);
+    private DigitalSignature(String rawSignature) {
+        super(rawSignature);
     }
 
     /** Serializes the value using {@link DataMapper}. */

--- a/data/src/main/java/org/example/age/data/certificate/SignedAgeCertificate.java
+++ b/data/src/main/java/org/example/age/data/certificate/SignedAgeCertificate.java
@@ -2,6 +2,8 @@ package org.example.age.data.certificate;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.security.PrivateKey;
+import java.security.PublicKey;
 import org.example.age.data.DataStyle;
 import org.immutables.value.Value;
 
@@ -12,6 +14,7 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableSignedAgeCertificate.class)
 public interface SignedAgeCertificate {
 
+    /** Creates a signed age certificate. */
     static SignedAgeCertificate of(AgeCertificate certificate, DigitalSignature signature) {
         return ImmutableSignedAgeCertificate.builder()
                 .ageCertificate(certificate)
@@ -19,9 +22,20 @@ public interface SignedAgeCertificate {
                 .build();
     }
 
+    /** Signs the age certificate. */
+    static SignedAgeCertificate sign(AgeCertificate certificate, PrivateKey privateKey) {
+        DigitalSignature signature = DigitalSignature.sign(certificate, privateKey);
+        return of(certificate, signature);
+    }
+
     /** Age certificate. */
     AgeCertificate ageCertificate();
 
     /** Signature for the age certificate. */
     DigitalSignature signature();
+
+    /** Verifies the signature against the age certificate, returning whether verification succeeded. */
+    default boolean verify(PublicKey publicKey) {
+        return signature().verify(ageCertificate(), publicKey);
+    }
 }

--- a/data/src/test/java/org/example/age/data/certificate/DigitalSignatureTest.java
+++ b/data/src/test/java/org/example/age/data/certificate/DigitalSignatureTest.java
@@ -23,24 +23,32 @@ public final class DigitalSignatureTest {
 
     @Test
     public void signThenVerify() {
-        DigitalSignature signature = DigitalSignature.create(MESSAGE, keyPair.getPrivate());
+        DigitalSignature signature = DigitalSignature.sign(MESSAGE, keyPair.getPrivate());
         boolean wasVerified = signature.verify(MESSAGE, keyPair.getPublic());
         assertThat(wasVerified).isTrue();
     }
 
     @Test
+    public void verifyFailed() {
+        DigitalSignature signature = DigitalSignature.sign(MESSAGE, keyPair.getPrivate());
+        boolean wasVerified = signature.verify("other message", keyPair.getPublic());
+        assertThat(wasVerified).isFalse();
+    }
+
+    @Test
+    public void serializeThenDeserialize() throws IOException {
+        DigitalSignature signature = DigitalSignature.sign(MESSAGE, keyPair.getPrivate());
+        byte[] rawSignature = DataMapper.get().writeValueAsBytes(signature);
+        DigitalSignature rtSignature = DataMapper.get().readValue(rawSignature, new TypeReference<>() {});
+        assertThat(rtSignature).isEqualTo(signature);
+    }
+
+    @Test
     public void signThenSerializeThenDeserializeThenVerify() throws IOException {
-        DigitalSignature signature = DigitalSignature.create(MESSAGE, keyPair.getPrivate());
+        DigitalSignature signature = DigitalSignature.sign(MESSAGE, keyPair.getPrivate());
         byte[] rawSignature = DataMapper.get().writeValueAsBytes(signature);
         DigitalSignature rtSignature = DataMapper.get().readValue(rawSignature, new TypeReference<>() {});
         boolean wasVerified = rtSignature.verify(MESSAGE, keyPair.getPublic());
         assertThat(wasVerified).isTrue();
-    }
-
-    @Test
-    public void verifyFailed() {
-        DigitalSignature signature = DigitalSignature.create(MESSAGE, keyPair.getPrivate());
-        boolean wasVerified = signature.verify("other message", keyPair.getPublic());
-        assertThat(wasVerified).isFalse();
     }
 }

--- a/data/src/test/java/org/example/age/data/certificate/SignedAgeCertificateTest.java
+++ b/data/src/test/java/org/example/age/data/certificate/SignedAgeCertificateTest.java
@@ -1,0 +1,69 @@
+package org.example.age.data.certificate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.io.IOException;
+import java.security.KeyPair;
+import java.time.Duration;
+import org.example.age.data.DataMapper;
+import org.example.age.data.SecureId;
+import org.example.age.data.VerifiedUser;
+import org.example.age.testing.crypto.TestKeys;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public final class SignedAgeCertificateTest {
+
+    private static KeyPair keyPair;
+
+    @BeforeAll
+    public static void generateKeys() {
+        keyPair = TestKeys.generateEd25519KeyPair();
+    }
+
+    @Test
+    public void signThenVerify() {
+        AgeCertificate certificate = createAgeCertificate();
+        SignedAgeCertificate signedCertificate = SignedAgeCertificate.sign(certificate, keyPair.getPrivate());
+        boolean wasVerified = signedCertificate.verify(keyPair.getPublic());
+        assertThat(wasVerified).isTrue();
+    }
+
+    @Test
+    public void verifyFailed() {
+        AgeCertificate certificate = createAgeCertificate();
+        DigitalSignature signature = DigitalSignature.ofBytes(new byte[1024]);
+        SignedAgeCertificate signedCertificate = SignedAgeCertificate.of(certificate, signature);
+        boolean wasVerified = signedCertificate.verify(keyPair.getPublic());
+        assertThat(wasVerified).isFalse();
+    }
+
+    @Test
+    public void serializeThenDeserialize() throws IOException {
+        AgeCertificate certificate = createAgeCertificate();
+        SignedAgeCertificate signedCertificate = SignedAgeCertificate.sign(certificate, keyPair.getPrivate());
+        byte[] rawSignedCertificate = DataMapper.get().writeValueAsBytes(signedCertificate);
+        SignedAgeCertificate rtSignedCertificate =
+                DataMapper.get().readValue(rawSignedCertificate, new TypeReference<>() {});
+        assertThat(rtSignedCertificate).isEqualTo(signedCertificate);
+    }
+
+    @Test
+    public void signThenSerializeThenDeserializeThenVerify() throws IOException {
+        AgeCertificate certificate = createAgeCertificate();
+        SignedAgeCertificate signedCertificate = SignedAgeCertificate.sign(certificate, keyPair.getPrivate());
+        byte[] rawSignedCertificate = DataMapper.get().writeValueAsBytes(signedCertificate);
+        SignedAgeCertificate rtSignedCertificate =
+                DataMapper.get().readValue(rawSignedCertificate, new TypeReference<>() {});
+        boolean wasVerified = rtSignedCertificate.verify(keyPair.getPublic());
+        assertThat(wasVerified).isTrue();
+    }
+
+    private static AgeCertificate createAgeCertificate() {
+        VerificationRequest request = VerificationRequest.generateForSite("Site", Duration.ofMinutes(5));
+        VerifiedUser user = VerifiedUser.of(SecureId.generate(), 18);
+        AuthToken authToken = AuthToken.empty();
+        return AgeCertificate.of(request, user, authToken);
+    }
+}


### PR DESCRIPTION
Individual verification tasks will be left to the site; there won't be a convenience method to run all the checks. Different checks may yield different error codes if they fail.