### PR TITLE
split off secure random immutable bytes

### DIFF
--- a/data/src/main/java/org/example/age/data/SecureId.java
+++ b/data/src/main/java/org/example/age/data/SecureId.java
@@ -8,13 +8,15 @@ import java.security.Key;
 import java.security.NoSuchAlgorithmException;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import org.example.age.data.internal.ImmutableBytes;
+import org.example.age.data.internal.SecureRandomImmutableBytes;
 import org.example.age.data.internal.StaticFromStringDeserializer;
 
 /** 256 random bits, generated via a secure random number generator. Can also be used as a key. */
 @JsonSerialize(using = ToStringSerializer.class)
 @JsonDeserialize(using = SecureId.Deserializer.class)
-public final class SecureId extends ImmutableBytes {
+public final class SecureId extends SecureRandomImmutableBytes {
+
+    private static final int EXPECTED_LENGTH = 32;
 
     /** Generates a new ID. */
     public static SecureId generate() {
@@ -43,19 +45,16 @@ public final class SecureId extends ImmutableBytes {
         return new SecureId(localBytes);
     }
 
-    @Override
-    protected int expectedLength() {
-        return 32;
+    private SecureId() {
+        super(EXPECTED_LENGTH);
     }
 
-    private SecureId() {}
-
     private SecureId(byte[] bytes) {
-        super(bytes);
+        super(bytes, EXPECTED_LENGTH);
     }
 
     private SecureId(String value) {
-        super(value);
+        super(value, EXPECTED_LENGTH);
     }
 
     /** Creates {@link Mac}'s. */

--- a/data/src/main/java/org/example/age/data/certificate/AuthKey.java
+++ b/data/src/main/java/org/example/age/data/certificate/AuthKey.java
@@ -5,13 +5,15 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import org.example.age.data.internal.ImmutableBytes;
+import org.example.age.data.internal.SecureRandomImmutableBytes;
 import org.example.age.data.internal.StaticFromStringDeserializer;
 
 /** Ephemeral AES-256 key used for encrypting authentication data. */
 @JsonSerialize(using = ToStringSerializer.class)
 @JsonDeserialize(using = AuthKey.Deserializer.class)
-public final class AuthKey extends ImmutableBytes {
+public final class AuthKey extends SecureRandomImmutableBytes {
+
+    private static final int EXPECTED_LENGTH = 32;
 
     private final SecretKey secretKey;
 
@@ -35,22 +37,18 @@ public final class AuthKey extends ImmutableBytes {
         return secretKey;
     }
 
-    @Override
-    protected int expectedLength() {
-        return 32;
-    }
-
     private AuthKey() {
+        super(EXPECTED_LENGTH);
         secretKey = SecretKeys.createAesKey(bytes);
     }
 
     private AuthKey(byte[] bytes) {
-        super(bytes);
+        super(bytes, EXPECTED_LENGTH);
         secretKey = SecretKeys.createAesKey(bytes);
     }
 
     private AuthKey(String value) {
-        super(value);
+        super(value, EXPECTED_LENGTH);
         secretKey = SecretKeys.createAesKey(bytes);
     }
 

--- a/data/src/main/java/org/example/age/data/internal/ImmutableBytes.java
+++ b/data/src/main/java/org/example/age/data/internal/ImmutableBytes.java
@@ -1,48 +1,37 @@
 package org.example.age.data.internal;
 
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Base64;
 
 /**
- * Type that is backed by immutable bytes, which can be converted to and from URL-friendly base64 text.
+ * Type that is backed by immutable bytes. The type can also be serialized as URL-friendly base64 text.
  *
  * <p>To serialize and deserialize a concrete implementation to and from JSON,
  * an implementation can use {@link ToStringSerializer} and {@link StaticFromStringDeserializer}.</p>
  *
- * <p>If the bytes have an expected length, {@link #expectedLength()} can be overridden to specify that length.</p>
- *
- * <p>Concrete implementations should have a flat hierarchy; {@link #equals(Object)} uses {@link Object#getClass()}.</p>
+ * <p>Concrete implementations should be {@code final}; {@link #equals(Object)} uses {@link Object#getClass()}.</p>
  */
 public abstract class ImmutableBytes {
 
     private static final Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
     private static final Base64.Decoder decoder = Base64.getUrlDecoder();
-    private static final SecureRandom random = new SecureRandom();
 
     protected final byte[] bytes;
 
-    /** Creates immutable bytes from a copy of the raw bytes. */
+    /** Creates immutable bytes from a copy of the bytes. */
     protected ImmutableBytes(byte[] bytes) {
-        this.bytes = Arrays.copyOf(bytes, bytes.length);
-        checkLength();
+        this(bytes, true);
     }
 
-    /** Creates immutable bytes from URL-friendly base64 text. */
-    protected ImmutableBytes(String value) {
-        this.bytes = decoder.decode(value);
-        checkLength();
+    /** Deserializes immutable bytes from URL-friendly base64 text. */
+    protected ImmutableBytes(String text) {
+        this(decoder.decode(text), false);
     }
 
-    /** Generates immutable bytes using a cryptographically strong random number generator. */
-    protected ImmutableBytes() {
-        if (expectedLength() == 0) {
-            throw new IllegalStateException("expected length must be set");
-        }
-
-        bytes = new byte[expectedLength()];
-        random.nextBytes(bytes);
+    /** Creates immutable bytes from the bytes, which may be copied. */
+    protected ImmutableBytes(byte[] bytes, boolean copy) {
+        this.bytes = copy ? Arrays.copyOf(bytes, bytes.length) : bytes;
     }
 
     /** Gets a copy of the raw bytes. */
@@ -50,7 +39,7 @@ public abstract class ImmutableBytes {
         return Arrays.copyOf(bytes, bytes.length);
     }
 
-    /** Converts the raw bytes to URL-friendly base64 text. */
+    /** Serializes the raw bytes to URL-friendly base64 text. */
     @Override
     public final String toString() {
         return encoder.encodeToString(bytes);
@@ -70,22 +59,5 @@ public abstract class ImmutableBytes {
     @Override
     public final int hashCode() {
         return Arrays.hashCode(bytes);
-    }
-
-    /** Gets the expected length in bytes, or 0 if any length is acceptable. Defaults to 0. */
-    protected int expectedLength() {
-        return 0;
-    }
-
-    /** Checks the length in bytes. */
-    private void checkLength() {
-        if (expectedLength() == 0) {
-            return;
-        }
-
-        if (bytes.length != expectedLength()) {
-            String message = String.format("expected %d bits", 8 * expectedLength());
-            throw new IllegalArgumentException(message);
-        }
     }
 }

--- a/data/src/main/java/org/example/age/data/internal/SecureRandomImmutableBytes.java
+++ b/data/src/main/java/org/example/age/data/internal/SecureRandomImmutableBytes.java
@@ -1,0 +1,44 @@
+package org.example.age.data.internal;
+
+import java.security.SecureRandom;
+
+/**
+ * Type that is backed by immutable bytes of a fixed length; the bytes are generated using
+ * a cryptographically strong random number generator. The type can also be serialized as URL-friendly base64 text.
+ */
+public abstract class SecureRandomImmutableBytes extends ImmutableBytes {
+
+    private static final SecureRandom random = new SecureRandom();
+
+    /** Creates immutable bytes from a copy of the bytes, checking the length of the bytes. */
+    protected SecureRandomImmutableBytes(byte[] bytes, int expectedLength) {
+        super(bytes);
+        checkLength(expectedLength);
+    }
+
+    /** Deserializes immutable bytes from URL-friendly base64 text, checking the length of the bytes. */
+    protected SecureRandomImmutableBytes(String text, int expectedLength) {
+        super(text);
+        checkLength(expectedLength);
+    }
+
+    /** Generates the specified number of bytes using a cryptographically strong random number generator. */
+    protected SecureRandomImmutableBytes(int length) {
+        super(generateRandomBytes(length), false);
+    }
+
+    /** Generates the specified number of bytes using a cryptographically strong random number generator. */
+    private static byte[] generateRandomBytes(int length) {
+        byte[] bytes = new byte[length];
+        random.nextBytes(bytes);
+        return bytes;
+    }
+
+    /** Checks that the bytes have the expected length. */
+    private void checkLength(int expectedLength) {
+        if (bytes.length != expectedLength) {
+            String message = String.format("expected %d bits", 8 * expectedLength);
+            throw new IllegalArgumentException(message);
+        }
+    }
+}

--- a/data/src/main/java/org/example/age/data/internal/StaticFromStringDeserializer.java
+++ b/data/src/main/java/org/example/age/data/internal/StaticFromStringDeserializer.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
 import java.util.function.Function;
 
 /**
- * Deserializes a class using a static {@code fromString()} factory method.
+ * Deserializes JSON into a type using a static {@code fromString()} factory method.
  *
  * <p>Concrete implementations only need to provide a public no-arg constructor.</p>
  */
@@ -19,7 +19,7 @@ public abstract class StaticFromStringDeserializer<T> extends FromStringDeserial
     }
 
     @Override
-    protected T _deserialize(String value, DeserializationContext context) {
+    protected final T _deserialize(String value, DeserializationContext context) {
         return fromString.apply(value);
     }
 }

--- a/data/src/test/java/org/example/age/data/internal/SecureRandomImmutableBytesTest.java
+++ b/data/src/test/java/org/example/age/data/internal/SecureRandomImmutableBytesTest.java
@@ -1,0 +1,84 @@
+package org.example.age.data.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import java.io.IOException;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.Test;
+
+public final class SecureRandomImmutableBytesTest {
+
+    @Test
+    public void generate() {
+        TestObject o = TestObject.generate();
+        assertThat(o.bytes()).hasSize(4);
+        assertThat(o.bytes()).isNotEqualTo(new byte[4]);
+    }
+
+    @Test
+    public void serializeThenDeserialize() throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        TestObject o = TestObject.generate();
+        byte[] rawO = mapper.writeValueAsBytes(o);
+        TestObject rtO = mapper.readValue(rawO, new TypeReference<>() {});
+        assertThat(rtO).isEqualTo(o);
+    }
+
+    @Test
+    public void error_IllegalLength() {
+        error_IllegalLength(() -> TestObject.ofBytes(new byte[1]));
+        error_IllegalLength(() -> TestObject.fromString("AA"));
+    }
+
+    private void error_IllegalLength(ThrowableAssert.ThrowingCallable callable) {
+        assertThatThrownBy(callable)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("expected 32 bits");
+    }
+
+    /** Test {@link SecureRandomImmutableBytes}. */
+    @JsonSerialize(using = ToStringSerializer.class)
+    @JsonDeserialize(using = TestObject.Deserializer.class)
+    private static final class TestObject extends SecureRandomImmutableBytes {
+
+        private static final int EXPECTED_LENGTH = 4;
+
+        public static TestObject ofBytes(byte[] rawO) {
+            return new TestObject(rawO);
+        }
+
+        public static TestObject fromString(String rawO) {
+            return new TestObject(rawO);
+        }
+
+        public static TestObject generate() {
+            return new TestObject();
+        }
+
+        private TestObject(byte[] rawO) {
+            super(rawO, EXPECTED_LENGTH);
+        }
+
+        private TestObject(String rawO) {
+            super(rawO, EXPECTED_LENGTH);
+        }
+
+        private TestObject() {
+            super(EXPECTED_LENGTH);
+        }
+
+        /** JSON {@code fromString()} deserializer. */
+        static final class Deserializer extends StaticFromStringDeserializer<TestObject> {
+
+            public Deserializer() {
+                super(TestObject.class, TestObject::fromString);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- `ImmutableBytes` are bytes of any length, has logic for serialization, `equals()`
- `SecureRandomImmutableBytes` securely generates random bytes of a fixed length