### PR TITLE
use sync API for extractors

### DIFF
--- a/common-api/src/main/java/org/example/age/common/api/data/AccountIdExtractor.java
+++ b/common-api/src/main/java/org/example/age/common/api/data/AccountIdExtractor.java
@@ -1,16 +1,15 @@
 package org.example.age.common.api.data;
 
 import io.undertow.server.HttpServerExchange;
-import java.util.Optional;
-import org.example.age.api.Sender;
+import org.example.age.api.HttpOptional;
 
 /**
- * Extracts an account ID from an {@link HttpServerExchange}, or sends an error status code.
+ * Extracts an account ID from an {@link HttpServerExchange}, or returns an error status code.
  *
  * <p>The account ID could be a username, or it could be an ephemeral ID for a session.</p>
  */
 @FunctionalInterface
 public interface AccountIdExtractor {
 
-    Optional<String> tryExtract(HttpServerExchange exchange, Sender sender);
+    HttpOptional<String> tryExtract(HttpServerExchange exchange);
 }

--- a/common-api/src/test/java/org/example/age/common/api/data/AuthMatchDataExtractorTest.java
+++ b/common-api/src/test/java/org/example/age/common/api/data/AuthMatchDataExtractorTest.java
@@ -1,21 +1,18 @@
 package org.example.age.common.api.data;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.example.age.testing.api.HttpOptionalAssert.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.undertow.server.HttpServerExchange;
-import java.util.Optional;
-import org.example.age.api.Sender;
+import org.example.age.api.HttpOptional;
 import org.example.age.data.crypto.Aes256Key;
 import org.example.age.data.crypto.AesGcmEncryptionPackage;
 import org.example.age.data.crypto.BytesValue;
-import org.example.age.testing.api.FakeCodeSender;
 import org.immutables.value.Value;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public final class AuthMatchDataExtractorTest {
@@ -23,7 +20,6 @@ public final class AuthMatchDataExtractorTest {
     private static AuthMatchDataExtractor dataExtractor;
 
     private static Aes256Key key;
-    private FakeCodeSender sender;
 
     @BeforeAll
     public static void createAuthMatchDataExtractorEtAl() {
@@ -31,35 +27,27 @@ public final class AuthMatchDataExtractorTest {
         key = Aes256Key.generate();
     }
 
-    @BeforeEach
-    public void createSender() {
-        sender = FakeCodeSender.create();
-    }
-
     @Test
     public void encryptThenDecrypt() {
         AuthMatchData data = TestAuthMatchData.of("data");
         AesGcmEncryptionPackage token = dataExtractor.encrypt(data, key);
-        Optional<AuthMatchData> maybeRtData = dataExtractor.tryDecrypt(token, key, sender);
+        HttpOptional<AuthMatchData> maybeRtData = dataExtractor.tryDecrypt(token, key);
         assertThat(maybeRtData).hasValue(data);
-        assertThat(sender.tryGet()).isEmpty();
     }
 
     @Test
     public void decryptFailed_Decryption() {
         AesGcmEncryptionPackage token = AesGcmEncryptionPackage.of(BytesValue.empty(), BytesValue.empty());
-        Optional<AuthMatchData> maybeRtData = dataExtractor.tryDecrypt(token, key, sender);
-        assertThat(maybeRtData).isEmpty();
-        assertThat(sender.tryGet()).hasValue(401);
+        HttpOptional<AuthMatchData> maybeRtData = dataExtractor.tryDecrypt(token, key);
+        assertThat(maybeRtData).isEmptyWithStatusCode(401);
     }
 
     @Test
     public void decryptFailed_Deserialization() {
         byte[] rawData = new byte[4];
         AesGcmEncryptionPackage token = AesGcmEncryptionPackage.encrypt(rawData, key);
-        Optional<AuthMatchData> maybeRtData = dataExtractor.tryDecrypt(token, key, sender);
-        assertThat(maybeRtData).isEmpty();
-        assertThat(sender.tryGet()).hasValue(400);
+        HttpOptional<AuthMatchData> maybeRtData = dataExtractor.tryDecrypt(token, key);
+        assertThat(maybeRtData).isEmptyWithStatusCode(400);
     }
 
     /** Test {@link AuthMatchDataExtractor}. */
@@ -70,7 +58,7 @@ public final class AuthMatchDataExtractorTest {
         }
 
         @Override
-        public Optional<AuthMatchData> tryExtract(HttpServerExchange exchange, Sender sender) {
+        public HttpOptional<AuthMatchData> tryExtract(HttpServerExchange exchange) {
             throw new UnsupportedOperationException();
         }
 

--- a/common-service/src/main/java/org/example/age/common/service/data/DisabledAuthMatchDataExtractor.java
+++ b/common-service/src/main/java/org/example/age/common/service/data/DisabledAuthMatchDataExtractor.java
@@ -3,10 +3,9 @@ package org.example.age.common.service.data;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.undertow.server.HttpServerExchange;
-import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.example.age.api.Sender;
+import org.example.age.api.HttpOptional;
 import org.example.age.common.api.data.AuthMatchData;
 import org.example.age.common.api.data.AuthMatchDataExtractor;
 
@@ -20,7 +19,7 @@ final class DisabledAuthMatchDataExtractor extends AuthMatchDataExtractor {
     }
 
     @Override
-    public Optional<AuthMatchData> tryExtract(HttpServerExchange exchange, Sender sender) {
-        return Optional.of(DisabledAuthMatchData.of());
+    public HttpOptional<AuthMatchData> tryExtract(HttpServerExchange exchange) {
+        return HttpOptional.of(DisabledAuthMatchData.of());
     }
 }

--- a/common-service/src/main/java/org/example/age/common/service/data/UserAgentAuthMatchDataExtractor.java
+++ b/common-service/src/main/java/org/example/age/common/service/data/UserAgentAuthMatchDataExtractor.java
@@ -4,10 +4,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
-import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.example.age.api.Sender;
+import org.example.age.api.HttpOptional;
 import org.example.age.common.api.data.AuthMatchData;
 import org.example.age.common.api.data.AuthMatchDataExtractor;
 
@@ -21,10 +20,10 @@ final class UserAgentAuthMatchDataExtractor extends AuthMatchDataExtractor {
     }
 
     @Override
-    public Optional<AuthMatchData> tryExtract(HttpServerExchange exchange, Sender sender) {
+    public HttpOptional<AuthMatchData> tryExtract(HttpServerExchange exchange) {
         String userAgent = exchange.getRequestHeaders().getFirst(Headers.USER_AGENT);
         userAgent = (userAgent != null) ? userAgent : "";
         AuthMatchData data = UserAgentAuthMatchData.of(userAgent);
-        return Optional.of(data);
+        return HttpOptional.of(data);
     }
 }

--- a/common-service/src/test/java/org/example/age/common/service/data/DisabledAuthMatchDataExtractorTest.java
+++ b/common-service/src/test/java/org/example/age/common/service/data/DisabledAuthMatchDataExtractorTest.java
@@ -1,22 +1,20 @@
 package org.example.age.common.service.data;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.example.age.testing.api.HttpOptionalAssert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
 import io.undertow.server.HttpServerExchange;
-import java.util.Optional;
 import javax.inject.Singleton;
+import org.example.age.api.HttpOptional;
 import org.example.age.common.api.data.AuthMatchData;
 import org.example.age.common.api.data.AuthMatchDataExtractor;
 import org.example.age.data.crypto.Aes256Key;
 import org.example.age.data.crypto.AesGcmEncryptionPackage;
-import org.example.age.testing.api.FakeCodeSender;
 import org.example.age.testing.exchange.StubExchanges;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public final class DisabledAuthMatchDataExtractorTest {
@@ -24,7 +22,6 @@ public final class DisabledAuthMatchDataExtractorTest {
     private static AuthMatchDataExtractor dataExtractor;
 
     private static Aes256Key key;
-    private FakeCodeSender sender;
 
     @BeforeAll
     public static void createAuthMatchDataExtractorEtAl() {
@@ -32,26 +29,20 @@ public final class DisabledAuthMatchDataExtractorTest {
         key = Aes256Key.generate();
     }
 
-    @BeforeEach
-    public void createSender() {
-        sender = FakeCodeSender.create();
-    }
-
     @Test
     public void extract() {
         HttpServerExchange exchange = StubExchanges.create();
-        Optional<AuthMatchData> maybeData = dataExtractor.tryExtract(exchange, sender);
-        assertThat(maybeData).isPresent();
-        assertThat(sender.tryGet()).isEmpty();
+        HttpOptional<AuthMatchData> maybeData = dataExtractor.tryExtract(exchange);
+        AuthMatchData expectedData = DisabledAuthMatchData.of();
+        assertThat(maybeData).hasValue(expectedData);
     }
 
     @Test
     public void encryptThenDecrypt() {
         AuthMatchData data = DisabledAuthMatchData.of();
         AesGcmEncryptionPackage token = dataExtractor.encrypt(data, key);
-        Optional<AuthMatchData> maybeRtData = dataExtractor.tryDecrypt(token, key, sender);
+        HttpOptional<AuthMatchData> maybeRtData = dataExtractor.tryDecrypt(token, key);
         assertThat(maybeRtData).hasValue(data);
-        assertThat(sender.tryGet()).isEmpty();
     }
 
     /** Dagger module that binds dependencies for {@link AuthMatchDataExtractor}. */

--- a/common-service/src/test/java/org/example/age/common/service/data/UserAgentAuthMatchDataExtractorTest.java
+++ b/common-service/src/test/java/org/example/age/common/service/data/UserAgentAuthMatchDataExtractorTest.java
@@ -1,6 +1,6 @@
 package org.example.age.common.service.data;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.example.age.testing.api.HttpOptionalAssert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dagger.Component;
@@ -8,16 +8,14 @@ import dagger.Module;
 import dagger.Provides;
 import io.undertow.server.HttpServerExchange;
 import java.util.Map;
-import java.util.Optional;
 import javax.inject.Singleton;
+import org.example.age.api.HttpOptional;
 import org.example.age.common.api.data.AuthMatchData;
 import org.example.age.common.api.data.AuthMatchDataExtractor;
 import org.example.age.data.crypto.Aes256Key;
 import org.example.age.data.crypto.AesGcmEncryptionPackage;
-import org.example.age.testing.api.FakeCodeSender;
 import org.example.age.testing.exchange.StubExchanges;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public final class UserAgentAuthMatchDataExtractorTest {
@@ -25,7 +23,6 @@ public final class UserAgentAuthMatchDataExtractorTest {
     private static AuthMatchDataExtractor dataExtractor;
 
     private static Aes256Key key;
-    private FakeCodeSender sender;
 
     @BeforeAll
     public static void createAuthMatchDataExtractorEtAl() {
@@ -33,36 +30,28 @@ public final class UserAgentAuthMatchDataExtractorTest {
         key = Aes256Key.generate();
     }
 
-    @BeforeEach
-    public void createSender() {
-        sender = FakeCodeSender.create();
-    }
-
     @Test
-    public void extract_HeaderPresent() {
+    public void extract() {
         HttpServerExchange exchange = StubExchanges.create(Map.of("User-Agent", "agent"));
-        Optional<AuthMatchData> maybeData = dataExtractor.tryExtract(exchange, sender);
+        HttpOptional<AuthMatchData> maybeData = dataExtractor.tryExtract(exchange);
         AuthMatchData expectedData = UserAgentAuthMatchData.of("agent");
         assertThat(maybeData).hasValue(expectedData);
-        assertThat(sender.tryGet()).isEmpty();
     }
 
     @Test
-    public void extract_HeaderNotPresent() {
+    public void extractFailed() {
         HttpServerExchange exchange = StubExchanges.create(Map.of());
-        Optional<AuthMatchData> maybeData = dataExtractor.tryExtract(exchange, sender);
+        HttpOptional<AuthMatchData> maybeData = dataExtractor.tryExtract(exchange);
         AuthMatchData expectedData = UserAgentAuthMatchData.of("");
         assertThat(maybeData).hasValue(expectedData);
-        assertThat(sender.tryGet()).isEmpty();
     }
 
     @Test
     public void encryptThenDecrypt() {
         AuthMatchData data = UserAgentAuthMatchData.of("agent");
         AesGcmEncryptionPackage token = dataExtractor.encrypt(data, key);
-        Optional<AuthMatchData> maybeRtData = dataExtractor.tryDecrypt(token, key, sender);
+        HttpOptional<AuthMatchData> maybeRtData = dataExtractor.tryDecrypt(token, key);
         assertThat(maybeRtData).hasValue(data);
-        assertThat(sender.tryGet()).isEmpty();
     }
 
     /** Dagger module that binds dependencies for {@link AuthMatchDataExtractor}. */

--- a/common/src/main/java/org/example/age/common/avs/verification/internal/VerificationManagerImpl.java
+++ b/common/src/main/java/org/example/age/common/avs/verification/internal/VerificationManagerImpl.java
@@ -99,10 +99,10 @@ final class VerificationManagerImpl implements VerificationManager {
         }
 
         PendingVerification pendingVerification = maybePendingVerification.get();
-        Optional<AesGcmEncryptionPackage> maybeAuthToken =
+        HttpOptional<AesGcmEncryptionPackage> maybeAuthToken =
                 tryExtractAuthToken(exchange, pendingVerification.verificationSession());
         if (maybeAuthToken.isEmpty()) {
-            return HttpOptional.empty(StatusCodes.BAD_REQUEST);
+            return HttpOptional.empty(maybeAuthToken.statusCode());
         }
 
         AesGcmEncryptionPackage authToken = maybeAuthToken.get();
@@ -132,16 +132,16 @@ final class VerificationManagerImpl implements VerificationManager {
     }
 
     /** Extracts an auth token from an {@link HttpServerExchange}. */
-    private Optional<AesGcmEncryptionPackage> tryExtractAuthToken(
+    private HttpOptional<AesGcmEncryptionPackage> tryExtractAuthToken(
             HttpServerExchange exchange, VerificationSession session) {
-        Optional<AuthMatchData> maybeAuthData = authDataExtractor.tryExtract(exchange, code -> {});
+        HttpOptional<AuthMatchData> maybeAuthData = authDataExtractor.tryExtract(exchange);
         if (maybeAuthData.isEmpty()) {
-            return Optional.empty();
+            return HttpOptional.empty(maybeAuthData.statusCode());
         }
 
         AuthMatchData authData = maybeAuthData.get();
         AesGcmEncryptionPackage authToken = authDataExtractor.encrypt(authData, session.authKey());
-        return Optional.of(authToken);
+        return HttpOptional.of(authToken);
     }
 
     /** Pending verification request for a specific site. */

--- a/common/src/main/java/org/example/age/common/site/api/SiteApiHandler.java
+++ b/common/src/main/java/org/example/age/common/site/api/SiteApiHandler.java
@@ -7,7 +7,6 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.StatusCodes;
 import java.io.IOException;
 import java.security.PublicKey;
-import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -16,6 +15,7 @@ import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import org.example.age.api.HttpOptional;
 import org.example.age.common.api.data.AccountIdExtractor;
 import org.example.age.common.base.client.internal.RequestDispatcher;
 import org.example.age.common.site.auth.internal.AuthManager;
@@ -76,9 +76,9 @@ final class SiteApiHandler implements HttpHandler {
 
     /** Handles a request to create a {@link VerificationSession} for an account. */
     private void handleVerificationSessionRequest(HttpServerExchange exchange) {
-        Optional<String> maybeAccountId = accountIdExtractor.tryExtract(exchange, code -> {});
+        HttpOptional<String> maybeAccountId = accountIdExtractor.tryExtract(exchange);
         if (maybeAccountId.isEmpty()) {
-            ExchangeUtils.sendStatusCode(exchange, StatusCodes.UNAUTHORIZED);
+            ExchangeUtils.sendStatusCode(exchange, maybeAccountId.statusCode());
             return;
         }
 

--- a/common/src/test/java/org/example/age/common/site/api/testing/FakeAvsHandler.java
+++ b/common/src/test/java/org/example/age/common/site/api/testing/FakeAvsHandler.java
@@ -111,8 +111,7 @@ public final class FakeAvsHandler implements HttpHandler {
     private AgeCertificate createAgeCertificate(SecureId pseudonym, HttpServerExchange exchange) {
         VerificationRequest request = session.verificationRequest();
         VerifiedUser user = VerifiedUser.of(pseudonym, 18);
-        AuthMatchData authData =
-                authDataExtractor.tryExtract(exchange, code -> {}).get();
+        AuthMatchData authData = authDataExtractor.tryExtract(exchange).get();
         AesGcmEncryptionPackage authToken = authDataExtractor.encrypt(authData, session.authKey());
         return AgeCertificate.of(request, user, authToken);
     }

--- a/common/src/test/java/org/example/age/common/site/auth/internal/AuthManagerTest.java
+++ b/common/src/test/java/org/example/age/common/site/auth/internal/AuthManagerTest.java
@@ -115,8 +115,7 @@ public final class AuthManagerTest {
     private AgeCertificate createCertification(VerificationSession session, HttpServerExchange exchange) {
         VerificationRequest request = session.verificationRequest();
         VerifiedUser user = VerifiedUser.of(SecureId.generate(), 18);
-        AuthMatchData authData =
-                authDataExtractor.tryExtract(exchange, code -> {}).get();
+        AuthMatchData authData = authDataExtractor.tryExtract(exchange).get();
         AesGcmEncryptionPackage authToken = authDataExtractor.encrypt(authData, authKey);
         return AgeCertificate.of(request, user, authToken);
     }

--- a/infra-api/src/test/java/org/example/age/infra/api/request/RequestParserTest.java
+++ b/infra-api/src/test/java/org/example/age/infra/api/request/RequestParserTest.java
@@ -7,11 +7,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import java.io.IOException;
-import java.util.Optional;
 import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import org.example.age.api.HttpOptional;
 import org.example.age.api.JsonSender;
 import org.example.age.infra.api.ExchangeJsonSender;
 import org.example.age.testing.client.TestClient;
@@ -90,8 +90,9 @@ public final class RequestParserTest {
 
         private static void handleAddRequest(HttpServerExchange exchange, RequestParser parser, int operand2) {
             JsonSender<Integer> sender = ExchangeJsonSender.create(exchange, mapper);
-            Optional<Integer> maybeOperand1 = parser.tryGetQueryParameter("operand", INT_TYPE);
+            HttpOptional<Integer> maybeOperand1 = parser.tryGetQueryParameter("operand", INT_TYPE);
             if (maybeOperand1.isEmpty()) {
+                sender.sendError(maybeOperand1.statusCode());
                 return;
             }
 

--- a/site-api/src/main/java/org/example/age/site/api/SiteEndpointHandler.java
+++ b/site-api/src/main/java/org/example/age/site/api/SiteEndpointHandler.java
@@ -5,11 +5,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.StatusCodes;
-import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.example.age.api.CodeSender;
 import org.example.age.api.Dispatcher;
+import org.example.age.api.HttpOptional;
 import org.example.age.api.JsonSender;
 import org.example.age.common.api.data.AccountIdExtractor;
 import org.example.age.common.api.data.AuthMatchData;
@@ -54,14 +54,16 @@ final class SiteEndpointHandler implements HttpHandler {
     private void handleVerificationSession(HttpServerExchange exchange) {
         JsonSender<VerificationSession> sender = ExchangeJsonSender.create(exchange, mapper);
 
-        Optional<String> maybeAccountId = accountIdExtractor.tryExtract(exchange, sender);
+        HttpOptional<String> maybeAccountId = accountIdExtractor.tryExtract(exchange);
         if (maybeAccountId.isEmpty()) {
+            sender.sendError(maybeAccountId.statusCode());
             return;
         }
         String accountId = maybeAccountId.get();
 
-        Optional<AuthMatchData> maybeAuthData = authDataExtractor.tryExtract(exchange, sender);
+        HttpOptional<AuthMatchData> maybeAuthData = authDataExtractor.tryExtract(exchange);
         if (maybeAuthData.isEmpty()) {
+            sender.sendError(maybeAuthData.statusCode());
             return;
         }
         AuthMatchData authData = maybeAuthData.get();

--- a/test-service/src/main/java/org/example/age/test/service/data/TestAccountIdExtractor.java
+++ b/test-service/src/main/java/org/example/age/test/service/data/TestAccountIdExtractor.java
@@ -5,7 +5,7 @@ import io.undertow.util.StatusCodes;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.example.age.api.Sender;
+import org.example.age.api.HttpOptional;
 import org.example.age.common.api.data.AccountIdExtractor;
 
 /** Extracts an account ID from the custom {@code Account-Id} header, or sends a 401 error. */
@@ -16,12 +16,9 @@ final class TestAccountIdExtractor implements AccountIdExtractor {
     public TestAccountIdExtractor() {}
 
     @Override
-    public Optional<String> tryExtract(HttpServerExchange exchange, Sender sender) {
+    public HttpOptional<String> tryExtract(HttpServerExchange exchange) {
         Optional<String> maybeAccountId =
                 Optional.ofNullable(exchange.getRequestHeaders().getFirst("Account-Id"));
-        if (maybeAccountId.isEmpty()) {
-            sender.sendError(StatusCodes.UNAUTHORIZED);
-        }
-        return maybeAccountId;
+        return HttpOptional.fromOptional(maybeAccountId, StatusCodes.UNAUTHORIZED);
     }
 }

--- a/test-service/src/test/java/org/example/age/test/service/data/TestAccountIdExtractorTest.java
+++ b/test-service/src/test/java/org/example/age/test/service/data/TestAccountIdExtractorTest.java
@@ -1,48 +1,38 @@
 package org.example.age.test.service.data;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.example.age.testing.api.HttpOptionalAssert.assertThat;
 
 import dagger.Component;
 import io.undertow.server.HttpServerExchange;
 import java.util.Map;
-import java.util.Optional;
 import javax.inject.Singleton;
+import org.example.age.api.HttpOptional;
 import org.example.age.common.api.data.AccountIdExtractor;
-import org.example.age.testing.api.FakeCodeSender;
 import org.example.age.testing.exchange.StubExchanges;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public final class TestAccountIdExtractorTest {
 
     private static AccountIdExtractor accountIdExtractor;
-    private FakeCodeSender sender;
 
     @BeforeAll
     public static void createAccountIdExtractor() {
         accountIdExtractor = TestComponent.createAccountIdExtractor();
     }
 
-    @BeforeEach
-    public void createSender() {
-        sender = FakeCodeSender.create();
-    }
-
     @Test
-    public void extractAccountId() {
+    public void extract_HeaderPresent() {
         HttpServerExchange exchange = StubExchanges.create(Map.of("Account-Id", "username"));
-        Optional<String> maybeAccountId = accountIdExtractor.tryExtract(exchange, sender);
+        HttpOptional<String> maybeAccountId = accountIdExtractor.tryExtract(exchange);
         assertThat(maybeAccountId).hasValue("username");
-        assertThat(sender.tryGet()).isEmpty();
     }
 
     @Test
-    public void sendError() {
+    public void extractEmpty_HeaderNotPresent() {
         HttpServerExchange exchange = StubExchanges.create(Map.of());
-        Optional<String> maybeAccountId = accountIdExtractor.tryExtract(exchange, sender);
-        assertThat(maybeAccountId).isEmpty();
-        assertThat(sender.tryGet()).hasValue(401);
+        HttpOptional<String> maybeAccountId = accountIdExtractor.tryExtract(exchange);
+        assertThat(maybeAccountId).isEmptyWithStatusCode(401);
     }
 
     /** Dagger component that provides an {@link AccountIdExtractor}. */


### PR DESCRIPTION
Includes `RequestParser.tryGetQueryParameter()`.

Easier to go from `HttpOptional` (sync) to `Sender` (async) than it is to go in the opposite direction.