### PR TITLE
fix: allow AuthMatchData interface to be serialized

### DIFF
--- a/common-api/src/main/java/org/example/age/common/api/data/AuthMatchData.java
+++ b/common-api/src/main/java/org/example/age/common/api/data/AuthMatchData.java
@@ -1,5 +1,7 @@
 package org.example.age.common.api.data;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 /**
  * Authentication data that is used to determine if two actions were performed by the same person.
  *
@@ -8,6 +10,7 @@ package org.example.age.common.api.data;
  *
  * <p>The data should be serializable as JSON.</p>
  */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 public interface AuthMatchData {
 
     /** Matches two sets of data, determining if they came from the same person. */

--- a/common-api/src/main/java/org/example/age/common/api/data/AuthMatchDataExtractor.java
+++ b/common-api/src/main/java/org/example/age/common/api/data/AuthMatchDataExtractor.java
@@ -19,7 +19,6 @@ import org.example.age.data.crypto.AesGcmEncryptionPackage;
 public abstract class AuthMatchDataExtractor {
 
     private final ObjectMapper mapper;
-    private final TypeReference<? extends AuthMatchData> dataTypeRef;
 
     /** Extracts {@link AuthMatchData} from an {@link HttpServerExchange}, or returns an error status code. */
     public abstract HttpOptional<AuthMatchData> tryExtract(HttpServerExchange exchange);
@@ -41,9 +40,8 @@ public abstract class AuthMatchDataExtractor {
         return tryDeserialize(rawData);
     }
 
-    protected AuthMatchDataExtractor(ObjectMapper mapper, TypeReference<? extends AuthMatchData> dataTypeRef) {
+    protected AuthMatchDataExtractor(ObjectMapper mapper) {
         this.mapper = mapper;
-        this.dataTypeRef = dataTypeRef;
     }
 
     /** Serializes {@link AuthMatchData}. */
@@ -58,7 +56,7 @@ public abstract class AuthMatchDataExtractor {
     /** Deserializes {@link AuthMatchData}, or returns a 400 error. */
     private HttpOptional<AuthMatchData> tryDeserialize(byte[] rawData) {
         try {
-            AuthMatchData data = mapper.readValue(rawData, dataTypeRef);
+            AuthMatchData data = mapper.readValue(rawData, new TypeReference<>() {});
             return HttpOptional.of(data);
         } catch (IOException e) {
             return HttpOptional.empty(StatusCodes.BAD_REQUEST);

--- a/common-api/src/test/java/org/example/age/common/api/data/AuthMatchDataExtractorTest.java
+++ b/common-api/src/test/java/org/example/age/common/api/data/AuthMatchDataExtractorTest.java
@@ -2,7 +2,6 @@ package org.example.age.common.api.data;
 
 import static org.example.age.testing.api.HttpOptionalAssert.assertThat;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -63,7 +62,7 @@ public final class AuthMatchDataExtractorTest {
         }
 
         private TestAuthMatchDataExtractor() {
-            super(new ObjectMapper(), new TypeReference<TestAuthMatchData>() {});
+            super(new ObjectMapper());
         }
     }
 

--- a/common-service/src/main/java/org/example/age/common/service/data/DisabledAuthMatchDataExtractor.java
+++ b/common-service/src/main/java/org/example/age/common/service/data/DisabledAuthMatchDataExtractor.java
@@ -1,6 +1,5 @@
 package org.example.age.common.service.data;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.undertow.server.HttpServerExchange;
 import javax.inject.Inject;
@@ -15,7 +14,7 @@ final class DisabledAuthMatchDataExtractor extends AuthMatchDataExtractor {
 
     @Inject
     public DisabledAuthMatchDataExtractor(ObjectMapper mapper) {
-        super(mapper, new TypeReference<DisabledAuthMatchData>() {});
+        super(mapper);
     }
 
     @Override

--- a/common-service/src/main/java/org/example/age/common/service/data/UserAgentAuthMatchDataExtractor.java
+++ b/common-service/src/main/java/org/example/age/common/service/data/UserAgentAuthMatchDataExtractor.java
@@ -1,6 +1,5 @@
 package org.example.age.common.service.data;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
@@ -16,7 +15,7 @@ final class UserAgentAuthMatchDataExtractor extends AuthMatchDataExtractor {
 
     @Inject
     public UserAgentAuthMatchDataExtractor(ObjectMapper mapper) {
-        super(mapper, new TypeReference<UserAgentAuthMatchData>() {});
+        super(mapper);
     }
 
     @Override


### PR DESCRIPTION
Concrete implementation types could be (de)serialized, but the interface type itself could not be (de)serialized.

Corollary: We no longer need a `TypeReference` arg for the `AuthMatchDataExtractor` class.