### PR TITLE
minor readability changes in api module

### DIFF
--- a/api/src/main/java/org/example/age/api/JsonSender.java
+++ b/api/src/main/java/org/example/age/api/JsonSender.java
@@ -9,7 +9,7 @@ public interface JsonSender<B> extends Sender {
     }
 
     @Override
-    default void sendError(int errorCode) {
+    default void sendErrorCode(int errorCode) {
         send(HttpOptional.empty(errorCode));
     }
 

--- a/api/src/main/java/org/example/age/api/Sender.java
+++ b/api/src/main/java/org/example/age/api/Sender.java
@@ -8,5 +8,5 @@ package org.example.age.api;
 @FunctionalInterface
 public interface Sender {
 
-    void sendError(int errorCode);
+    void sendErrorCode(int errorCode);
 }

--- a/api/src/main/java/org/example/age/api/StatusCodeSender.java
+++ b/api/src/main/java/org/example/age/api/StatusCodeSender.java
@@ -2,14 +2,14 @@ package org.example.age.api;
 
 /** Response sender that only sends a status code. */
 @FunctionalInterface
-public interface CodeSender extends Sender {
+public interface StatusCodeSender extends Sender {
 
     default void sendOk() {
         send(200);
     }
 
     @Override
-    default void sendError(int errorCode) {
+    default void sendErrorCode(int errorCode) {
         send(errorCode);
     }
 

--- a/api/src/test/java/org/example/age/testing/api/FakeStatusCodeSenderTest.java
+++ b/api/src/test/java/org/example/age/testing/api/FakeStatusCodeSenderTest.java
@@ -6,26 +6,26 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public final class FakeCodeSenderTest {
+public final class FakeStatusCodeSenderTest {
 
-    private FakeCodeSender sender;
+    private FakeStatusCodeSender sender;
 
     @BeforeEach
-    public void createCodeSender() {
-        sender = FakeCodeSender.create();
+    public void createStatusCodeSender() {
+        sender = FakeStatusCodeSender.create();
     }
 
     @Test
     public void sendAndGet() {
         assertThat(sender.tryGet()).isEmpty();
-        sender.sendError(403);
+        sender.sendErrorCode(403);
         assertThat(sender.tryGet()).hasValue(403);
     }
 
     @Test
     public void error_SendTwice() {
-        sender.sendError(403);
-        assertThatThrownBy(() -> sender.sendError(200))
+        sender.sendErrorCode(403);
+        assertThatThrownBy(() -> sender.sendErrorCode(200))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("response was already sent");
     }

--- a/api/src/testFixtures/java/org/example/age/testing/api/FakeStatusCodeSender.java
+++ b/api/src/testFixtures/java/org/example/age/testing/api/FakeStatusCodeSender.java
@@ -1,16 +1,16 @@
 package org.example.age.testing.api;
 
 import java.util.OptionalInt;
-import org.example.age.api.CodeSender;
+import org.example.age.api.StatusCodeSender;
 
-/** Fake {@link CodeSender} that stores the status code that was sent. */
-public final class FakeCodeSender implements CodeSender {
+/** Fake {@link StatusCodeSender} that stores the status code that was sent. */
+public final class FakeStatusCodeSender implements StatusCodeSender {
 
     private OptionalInt maybeStatusCode = OptionalInt.empty();
 
-    /** Creates a {@link FakeCodeSender}. */
-    public static FakeCodeSender create() {
-        return new FakeCodeSender();
+    /** Creates a {@link FakeStatusCodeSender}. */
+    public static FakeStatusCodeSender create() {
+        return new FakeStatusCodeSender();
     }
 
     /** Gets the status code that was sent, if a response was sent. */
@@ -27,5 +27,5 @@ public final class FakeCodeSender implements CodeSender {
         maybeStatusCode = OptionalInt.of(statusCode);
     }
 
-    private FakeCodeSender() {}
+    private FakeStatusCodeSender() {}
 }

--- a/avs-api/src/main/java/org/example/age/avs/api/AvsApi.java
+++ b/avs-api/src/main/java/org/example/age/avs/api/AvsApi.java
@@ -1,8 +1,8 @@
 package org.example.age.avs.api;
 
-import org.example.age.api.CodeSender;
 import org.example.age.api.Dispatcher;
 import org.example.age.api.JsonSender;
+import org.example.age.api.StatusCodeSender;
 import org.example.age.common.api.data.AuthMatchData;
 import org.example.age.data.certificate.AgeCertificate;
 import org.example.age.data.certificate.VerificationRequest;
@@ -16,8 +16,8 @@ public interface AvsApi {
     void createVerificationSession(JsonSender<VerificationSession> sender, String siteId, Dispatcher dispatcher);
 
     /** Links a pending {@link VerificationRequest} to an account. */
-    void linkVerificationRequest(CodeSender sender, String accountId, SecureId requestId, Dispatcher dispatcher);
+    void linkVerificationRequest(StatusCodeSender sender, String accountId, SecureId requestId, Dispatcher dispatcher);
 
     /** Sends an {@link AgeCertificate} for the pending {@link VerificationRequest} that is linked to the account. */
-    void sendAgeCertificate(CodeSender sender, String accountId, AuthMatchData authData, Dispatcher dispatcher);
+    void sendAgeCertificate(StatusCodeSender sender, String accountId, AuthMatchData authData, Dispatcher dispatcher);
 }

--- a/avs-api/src/main/java/org/example/age/avs/api/AvsEndpointHandler.java
+++ b/avs-api/src/main/java/org/example/age/avs/api/AvsEndpointHandler.java
@@ -6,19 +6,19 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.StatusCodes;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.example.age.api.CodeSender;
 import org.example.age.api.Dispatcher;
 import org.example.age.api.HttpOptional;
 import org.example.age.api.JsonSender;
 import org.example.age.api.JsonSerializer;
+import org.example.age.api.StatusCodeSender;
 import org.example.age.common.api.data.AccountIdExtractor;
 import org.example.age.common.api.data.AuthMatchData;
 import org.example.age.common.api.data.AuthMatchDataExtractor;
 import org.example.age.data.certificate.VerificationSession;
 import org.example.age.data.crypto.SecureId;
-import org.example.age.infra.api.ExchangeCodeSender;
 import org.example.age.infra.api.ExchangeDispatcher;
 import org.example.age.infra.api.ExchangeJsonSender;
+import org.example.age.infra.api.ExchangeStatusCodeSender;
 import org.example.age.infra.api.request.RequestParser;
 
 @Singleton
@@ -48,7 +48,7 @@ final class AvsEndpointHandler implements HttpHandler {
             case "/verification-session" -> handleVerificationSession(exchange, parser);
             case "/linked-verification-request" -> handleLinkedVerificationRequest(exchange, parser);
             case "/age-certificate" -> handleAgeCertificate(exchange);
-            default -> ExchangeCodeSender.create(exchange).sendError(StatusCodes.NOT_FOUND);
+            default -> ExchangeStatusCodeSender.create(exchange).sendErrorCode(StatusCodes.NOT_FOUND);
         }
     }
 
@@ -57,7 +57,7 @@ final class AvsEndpointHandler implements HttpHandler {
 
         HttpOptional<String> maybeSiteId = parser.tryGetQueryParameter("site-id");
         if (maybeSiteId.isEmpty()) {
-            sender.sendError(maybeSiteId.statusCode());
+            sender.sendErrorCode(maybeSiteId.statusCode());
             return;
         }
         String siteId = maybeSiteId.get();
@@ -67,18 +67,18 @@ final class AvsEndpointHandler implements HttpHandler {
     }
 
     private void handleLinkedVerificationRequest(HttpServerExchange exchange, RequestParser parser) {
-        CodeSender sender = ExchangeCodeSender.create(exchange);
+        StatusCodeSender sender = ExchangeStatusCodeSender.create(exchange);
 
         HttpOptional<String> maybeAccountId = accountIdExtractor.tryExtract(exchange);
         if (maybeAccountId.isEmpty()) {
-            sender.sendError(maybeAccountId.statusCode());
+            sender.sendErrorCode(maybeAccountId.statusCode());
             return;
         }
         String accountId = maybeAccountId.get();
 
         HttpOptional<SecureId> maybeRequestId = parser.tryGetQueryParameter("request-id", new TypeReference<>() {});
         if (maybeRequestId.isEmpty()) {
-            sender.sendError(maybeRequestId.statusCode());
+            sender.sendErrorCode(maybeRequestId.statusCode());
             return;
         }
         SecureId requestId = maybeRequestId.get();
@@ -88,18 +88,18 @@ final class AvsEndpointHandler implements HttpHandler {
     }
 
     private void handleAgeCertificate(HttpServerExchange exchange) {
-        CodeSender sender = ExchangeCodeSender.create(exchange);
+        StatusCodeSender sender = ExchangeStatusCodeSender.create(exchange);
 
         HttpOptional<String> maybeAccountId = accountIdExtractor.tryExtract(exchange);
         if (maybeAccountId.isEmpty()) {
-            sender.sendError(maybeAccountId.statusCode());
+            sender.sendErrorCode(maybeAccountId.statusCode());
             return;
         }
         String accountId = maybeAccountId.get();
 
         HttpOptional<AuthMatchData> maybeAuthData = authDataExtractor.tryExtract(exchange);
         if (maybeAuthData.isEmpty()) {
-            sender.sendError(maybeAuthData.statusCode());
+            sender.sendErrorCode(maybeAuthData.statusCode());
             return;
         }
         AuthMatchData authData = maybeAuthData.get();

--- a/avs-api/src/testFixtures/java/org/example/age/test/avs/service/StubAvsService.java
+++ b/avs-api/src/testFixtures/java/org/example/age/test/avs/service/StubAvsService.java
@@ -3,9 +3,9 @@ package org.example.age.test.avs.service;
 import java.time.Duration;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.example.age.api.CodeSender;
 import org.example.age.api.Dispatcher;
 import org.example.age.api.JsonSender;
+import org.example.age.api.StatusCodeSender;
 import org.example.age.avs.api.AvsApi;
 import org.example.age.common.api.data.AuthMatchData;
 import org.example.age.data.certificate.VerificationRequest;
@@ -29,12 +29,13 @@ public final class StubAvsService implements AvsApi {
 
     @Override
     public void linkVerificationRequest(
-            CodeSender sender, String accountId, SecureId requestId, Dispatcher dispatcher) {
+            StatusCodeSender sender, String accountId, SecureId requestId, Dispatcher dispatcher) {
         sender.sendOk();
     }
 
     @Override
-    public void sendAgeCertificate(CodeSender sender, String accountId, AuthMatchData authData, Dispatcher dispatcher) {
+    public void sendAgeCertificate(
+            StatusCodeSender sender, String accountId, AuthMatchData authData, Dispatcher dispatcher) {
         sender.sendOk();
     }
 }

--- a/infra-api/src/main/java/org/example/age/infra/api/ExchangeJsonSender.java
+++ b/infra-api/src/main/java/org/example/age/infra/api/ExchangeJsonSender.java
@@ -27,7 +27,7 @@ public final class ExchangeJsonSender<B> implements JsonSender<B> {
         }
 
         if (maybeBody.isEmpty()) {
-            sendErrorCode(maybeBody.statusCode());
+            sendErrorCodeInternal(maybeBody.statusCode());
             return;
         }
 
@@ -43,7 +43,7 @@ public final class ExchangeJsonSender<B> implements JsonSender<B> {
     }
 
     /** Sends an error status code. */
-    private void sendErrorCode(int errorCode) {
+    private void sendErrorCodeInternal(int errorCode) {
         exchange.setStatusCode(errorCode);
         exchange.endExchange();
     }

--- a/infra-api/src/main/java/org/example/age/infra/api/ExchangeStatusCodeSender.java
+++ b/infra-api/src/main/java/org/example/age/infra/api/ExchangeStatusCodeSender.java
@@ -2,17 +2,17 @@ package org.example.age.infra.api;
 
 import io.undertow.server.HttpServerExchange;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.example.age.api.CodeSender;
+import org.example.age.api.StatusCodeSender;
 
-/** {@link CodeSender} that is backed by an {@link HttpServerExchange}. */
-public final class ExchangeCodeSender implements CodeSender {
+/** {@link StatusCodeSender} that is backed by an {@link HttpServerExchange}. */
+public final class ExchangeStatusCodeSender implements StatusCodeSender {
 
     private final HttpServerExchange exchange;
     private final AtomicBoolean wasSent = new AtomicBoolean(false);
 
-    /** Creates the {@link CodeSender} from the {@link HttpServerExchange}. */
-    public static CodeSender create(HttpServerExchange exchange) {
-        return new ExchangeCodeSender(exchange);
+    /** Creates the {@link StatusCodeSender} from the {@link HttpServerExchange}. */
+    public static StatusCodeSender create(HttpServerExchange exchange) {
+        return new ExchangeStatusCodeSender(exchange);
     }
 
     @Override
@@ -25,7 +25,7 @@ public final class ExchangeCodeSender implements CodeSender {
         exchange.endExchange();
     }
 
-    private ExchangeCodeSender(HttpServerExchange exchange) {
+    private ExchangeStatusCodeSender(HttpServerExchange exchange) {
         this.exchange = exchange;
     }
 }

--- a/infra-api/src/test/java/org/example/age/infra/api/ExchangeDispatcherTest.java
+++ b/infra-api/src/test/java/org/example/age/infra/api/ExchangeDispatcherTest.java
@@ -7,8 +7,8 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.StatusCodes;
 import java.io.IOException;
 import okhttp3.Response;
-import org.example.age.api.CodeSender;
 import org.example.age.api.Dispatcher;
+import org.example.age.api.StatusCodeSender;
 import org.example.age.testing.client.TestClient;
 import org.example.age.testing.server.TestUndertowServer;
 import org.junit.jupiter.api.Test;
@@ -59,7 +59,7 @@ public final class ExchangeDispatcherTest {
         @Override
         public void handleRequest(HttpServerExchange exchange) {
             Dispatcher dispatcher = ExchangeDispatcher.create(exchange);
-            CodeSender sender = ExchangeCodeSender.create(exchange);
+            StatusCodeSender sender = ExchangeStatusCodeSender.create(exchange);
             if (!dispatcher.isInIoThread()) {
                 sender.send(418);
                 return;
@@ -75,22 +75,22 @@ public final class ExchangeDispatcherTest {
             }
         }
 
-        private static void dispatchedIoThread(CodeSender sender, Dispatcher dispatcher) {
+        private static void dispatchedIoThread(StatusCodeSender sender, Dispatcher dispatcher) {
             dispatcher.getIoThread().execute(() -> dispatcher.executeHandler(sender, TestHandler::ioThreadHandler));
             dispatcher.dispatched();
         }
 
-        private static void dispatchedWorker(CodeSender sender, Dispatcher dispatcher) {
+        private static void dispatchedWorker(StatusCodeSender sender, Dispatcher dispatcher) {
             dispatcher.getWorker().execute(() -> dispatcher.executeHandler(sender, TestHandler::handler));
             dispatcher.dispatched();
         }
 
-        private static void dispatchedBadHandler(CodeSender sender, Dispatcher dispatcher) {
+        private static void dispatchedBadHandler(StatusCodeSender sender, Dispatcher dispatcher) {
             dispatcher.getWorker().execute(() -> dispatcher.executeHandler(sender, TestHandler::badHandler));
             dispatcher.dispatched();
         }
 
-        private static void handler(CodeSender sender, Dispatcher dispatcher) {
+        private static void handler(StatusCodeSender sender, Dispatcher dispatcher) {
             if (dispatcher.isInIoThread()) {
                 sender.send(418);
                 return;
@@ -99,7 +99,7 @@ public final class ExchangeDispatcherTest {
             sender.sendOk();
         }
 
-        private static void ioThreadHandler(CodeSender sender, Dispatcher dispatcher) {
+        private static void ioThreadHandler(StatusCodeSender sender, Dispatcher dispatcher) {
             if (!dispatcher.isInIoThread()) {
                 sender.send(418);
                 return;
@@ -108,7 +108,7 @@ public final class ExchangeDispatcherTest {
             sender.sendOk();
         }
 
-        private static void badHandler(CodeSender sender, Dispatcher dispatcher) {
+        private static void badHandler(StatusCodeSender sender, Dispatcher dispatcher) {
             throw new RuntimeException();
         }
 

--- a/infra-api/src/test/java/org/example/age/infra/api/ExchangeJsonSenderTest.java
+++ b/infra-api/src/test/java/org/example/age/infra/api/ExchangeJsonSenderTest.java
@@ -26,7 +26,7 @@ public final class ExchangeJsonSenderTest {
     }
 
     @Test
-    public void send_Error() throws IOException {
+    public void send_ErrorCode() throws IOException {
         sendError("/forbidden", 403);
     }
 
@@ -68,10 +68,10 @@ public final class ExchangeJsonSenderTest {
             JsonSender<String> sender = ExchangeJsonSender.create(exchange, serializer);
             switch (exchange.getRequestPath()) {
                 case "/body" -> sender.sendBody("test");
-                case "/forbidden" -> sender.sendError(StatusCodes.FORBIDDEN);
+                case "/forbidden" -> sender.sendErrorCode(StatusCodes.FORBIDDEN);
                 case "/send-twice" -> sendTwice(sender);
                 case "/serialization-failed" -> serializationFailed(exchange);
-                default -> sender.sendError(StatusCodes.NOT_FOUND);
+                default -> sender.sendErrorCode(StatusCodes.NOT_FOUND);
             }
         }
 

--- a/infra-api/src/test/java/org/example/age/infra/api/ExchangeStatusCodeSenderTest.java
+++ b/infra-api/src/test/java/org/example/age/infra/api/ExchangeStatusCodeSenderTest.java
@@ -7,13 +7,13 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.StatusCodes;
 import java.io.IOException;
 import okhttp3.Response;
-import org.example.age.api.CodeSender;
+import org.example.age.api.StatusCodeSender;
 import org.example.age.testing.client.TestClient;
 import org.example.age.testing.server.TestUndertowServer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public final class ExchangeCodeSenderTest {
+public final class ExchangeStatusCodeSenderTest {
 
     @RegisterExtension
     private static final TestUndertowServer server = TestUndertowServer.create(TestHandler::create);
@@ -24,7 +24,7 @@ public final class ExchangeCodeSenderTest {
     }
 
     @Test
-    public void send_Error() throws IOException {
+    public void send_ErrorCode() throws IOException {
         send("/forbidden", 403);
     }
 
@@ -38,7 +38,7 @@ public final class ExchangeCodeSenderTest {
         assertThat(response.code()).isEqualTo(expectedStatusCode);
     }
 
-    /** Test {@link HttpHandler} that uses an {@link ExchangeCodeSender}. */
+    /** Test {@link HttpHandler} that uses an {@link ExchangeStatusCodeSender}. */
     private static final class TestHandler implements HttpHandler {
 
         public static HttpHandler create() {
@@ -47,7 +47,7 @@ public final class ExchangeCodeSenderTest {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) {
-            CodeSender sender = ExchangeCodeSender.create(exchange);
+            StatusCodeSender sender = ExchangeStatusCodeSender.create(exchange);
             switch (exchange.getRequestPath()) {
                 case "/ok" -> sender.sendOk();
                 case "/forbidden" -> sender.send(StatusCodes.FORBIDDEN);
@@ -56,7 +56,7 @@ public final class ExchangeCodeSenderTest {
             }
         }
 
-        private static void sendTwice(CodeSender sender) {
+        private static void sendTwice(StatusCodeSender sender) {
             sender.sendOk();
             sender.send(StatusCodes.FORBIDDEN);
         }

--- a/infra-api/src/test/java/org/example/age/infra/api/request/RequestParserTest.java
+++ b/infra-api/src/test/java/org/example/age/infra/api/request/RequestParserTest.java
@@ -93,7 +93,7 @@ public final class RequestParserTest {
             JsonSender<Integer> sender = ExchangeJsonSender.create(exchange, serializer);
             HttpOptional<Integer> maybeOperand1 = parser.tryGetQueryParameter("operand", INT_TYPE);
             if (maybeOperand1.isEmpty()) {
-                sender.sendError(maybeOperand1.statusCode());
+                sender.sendErrorCode(maybeOperand1.statusCode());
                 return;
             }
 

--- a/infra-service/src/main/java/org/example/age/infra/service/client/RequestDispatcherImpl.java
+++ b/infra-service/src/main/java/org/example/age/infra/service/client/RequestDispatcherImpl.java
@@ -52,7 +52,7 @@ final class RequestDispatcherImpl implements RequestDispatcher {
 
     /** Sends a 502 error when the request fails. */
     private static void requestFailed(Sender sender) {
-        sender.sendError(502);
+        sender.sendErrorCode(502);
     }
 
     /** Adapts a {@link ResponseCallback} to a {@link Callback}. */

--- a/infra-service/src/test/java/org/example/age/infra/service/client/RequestDispatcherTest.java
+++ b/infra-service/src/test/java/org/example/age/infra/service/client/RequestDispatcherTest.java
@@ -16,13 +16,13 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.SocketPolicy;
-import org.example.age.api.CodeSender;
 import org.example.age.api.Dispatcher;
 import org.example.age.api.JsonSender;
 import org.example.age.api.JsonSerializer;
-import org.example.age.infra.api.ExchangeCodeSender;
+import org.example.age.api.StatusCodeSender;
 import org.example.age.infra.api.ExchangeDispatcher;
 import org.example.age.infra.api.ExchangeJsonSender;
+import org.example.age.infra.api.ExchangeStatusCodeSender;
 import org.example.age.infra.api.data.JsonSerializerModule;
 import org.example.age.test.infra.service.data.TestMapperModule;
 import org.example.age.testing.client.TestClient;
@@ -112,12 +112,12 @@ public final class RequestDispatcherTest {
             switch (exchange.getRequestPath()) {
                 case "/response" -> handleResponse(exchange);
                 case "/response-body" -> handleResponseBody(exchange);
-                default -> ExchangeCodeSender.create(exchange).sendError(StatusCodes.NOT_FOUND);
+                default -> ExchangeStatusCodeSender.create(exchange).sendErrorCode(StatusCodes.NOT_FOUND);
             }
         }
 
         private void handleResponse(HttpServerExchange exchange) {
-            CodeSender sender = ExchangeCodeSender.create(exchange);
+            StatusCodeSender sender = ExchangeStatusCodeSender.create(exchange);
             Dispatcher dispatcher = ExchangeDispatcher.create(exchange);
             Request request = new Request.Builder().url(backendServer.rootUrl()).build();
             requestDispatcher.dispatch(request, sender, dispatcher, this::onResponseReceived);
@@ -131,14 +131,14 @@ public final class RequestDispatcherTest {
                     request, new TypeReference<>() {}, sender, dispatcher, this::onResponseBodyReceived);
         }
 
-        private void onResponseReceived(Response response, CodeSender sender, Dispatcher dispatcher) {
+        private void onResponseReceived(Response response, StatusCodeSender sender, Dispatcher dispatcher) {
             sender.send(response.code());
         }
 
         private void onResponseBodyReceived(
                 Response response, String responseBody, JsonSender<String> sender, Dispatcher dispatcher) {
             if (!response.isSuccessful()) {
-                sender.sendError(response.code());
+                sender.sendErrorCode(response.code());
                 return;
             }
 

--- a/infra-service/src/test/java/org/example/age/infra/service/client/internal/ExchangeClientTest.java
+++ b/infra-service/src/test/java/org/example/age/infra/service/client/internal/ExchangeClientTest.java
@@ -87,14 +87,14 @@ public final class ExchangeClientTest {
 
             @Override
             public void onFailure(Call call, IOException e) {
-                sender.sendError(StatusCodes.BAD_GATEWAY);
+                sender.sendErrorCode(StatusCodes.BAD_GATEWAY);
             }
 
             private void onRecipientReceived(Response response, JsonSender<String> sender) throws IOException {
                 HttpOptional<String> maybeRecipient =
                         serializer.tryDeserialize(response.body().bytes(), new TypeReference<>() {}, 400);
                 if (maybeRecipient.isEmpty()) {
-                    sender.sendError(maybeRecipient.statusCode());
+                    sender.sendErrorCode(maybeRecipient.statusCode());
                     return;
                 }
                 String recipient = maybeRecipient.get();

--- a/site-api/src/main/java/org/example/age/site/api/SiteApi.java
+++ b/site-api/src/main/java/org/example/age/site/api/SiteApi.java
@@ -1,8 +1,8 @@
 package org.example.age.site.api;
 
-import org.example.age.api.CodeSender;
 import org.example.age.api.Dispatcher;
 import org.example.age.api.JsonSender;
+import org.example.age.api.StatusCodeSender;
 import org.example.age.common.api.data.AuthMatchData;
 import org.example.age.data.certificate.SignedAgeCertificate;
 import org.example.age.data.certificate.VerificationSession;
@@ -15,5 +15,5 @@ public interface SiteApi {
             JsonSender<VerificationSession> sender, String accountId, AuthMatchData authData, Dispatcher dispatcher);
 
     /** Processes a {@link SignedAgeCertificate} from the age verification service. */
-    void processAgeCertificate(CodeSender sender, SignedAgeCertificate signedCertificate, Dispatcher dispatcher);
+    void processAgeCertificate(StatusCodeSender sender, SignedAgeCertificate signedCertificate, Dispatcher dispatcher);
 }

--- a/site-api/src/testFixtures/java/org/example/age/test/site/service/StubSiteService.java
+++ b/site-api/src/testFixtures/java/org/example/age/test/site/service/StubSiteService.java
@@ -3,9 +3,9 @@ package org.example.age.test.site.service;
 import java.time.Duration;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.example.age.api.CodeSender;
 import org.example.age.api.Dispatcher;
 import org.example.age.api.JsonSender;
+import org.example.age.api.StatusCodeSender;
 import org.example.age.common.api.data.AuthMatchData;
 import org.example.age.data.certificate.SignedAgeCertificate;
 import org.example.age.data.certificate.VerificationRequest;
@@ -29,7 +29,7 @@ public final class StubSiteService implements SiteApi {
 
     @Override
     public void processAgeCertificate(
-            CodeSender sender, SignedAgeCertificate signedCertificate, Dispatcher dispatcher) {
+            StatusCodeSender sender, SignedAgeCertificate signedCertificate, Dispatcher dispatcher) {
         sender.sendOk();
     }
 }

--- a/site-service/src/main/java/org/example/age/site/service/SiteService.java
+++ b/site-service/src/main/java/org/example/age/site/service/SiteService.java
@@ -9,9 +9,9 @@ import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import org.example.age.api.CodeSender;
 import org.example.age.api.Dispatcher;
 import org.example.age.api.JsonSender;
+import org.example.age.api.StatusCodeSender;
 import org.example.age.common.api.data.AuthMatchData;
 import org.example.age.data.certificate.SignedAgeCertificate;
 import org.example.age.data.certificate.VerificationSession;
@@ -54,7 +54,7 @@ final class SiteService implements SiteApi {
 
     @Override
     public void processAgeCertificate(
-            CodeSender sender, SignedAgeCertificate signedCertificate, Dispatcher dispatcher) {
+            StatusCodeSender sender, SignedAgeCertificate signedCertificate, Dispatcher dispatcher) {
         int statusCode = verificationManager.onSignedAgeCertificateReceived(signedCertificate);
         sender.send(statusCode);
     }
@@ -81,14 +81,14 @@ final class SiteService implements SiteApi {
                 Dispatcher dispatcher) {
             if (!response.isSuccessful()) {
                 int errorCode = ((response.code() / 100) == 5) ? 502 : 500;
-                sender.sendError(errorCode);
+                sender.sendErrorCode(errorCode);
                 return;
             }
 
             int statusCode =
                     verificationManager.onVerificationSessionReceived(accountId, authData, session, dispatcher);
             if (statusCode != 200) {
-                sender.sendError(statusCode);
+                sender.sendErrorCode(statusCode);
                 return;
             }
 

--- a/site-service/src/testFixtures/java/org/example/age/test/avs/service/FakeAvsService.java
+++ b/site-service/src/testFixtures/java/org/example/age/test/avs/service/FakeAvsService.java
@@ -12,10 +12,10 @@ import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import org.example.age.api.CodeSender;
 import org.example.age.api.Dispatcher;
 import org.example.age.api.JsonSender;
 import org.example.age.api.JsonSerializer;
+import org.example.age.api.StatusCodeSender;
 import org.example.age.avs.api.AvsApi;
 import org.example.age.avs.api.SiteLocation;
 import org.example.age.common.api.data.AuthMatchData;
@@ -70,11 +70,11 @@ final class FakeAvsService implements AvsApi {
 
     @Override
     public void linkVerificationRequest(
-            CodeSender sender, String accountId, SecureId requestId, Dispatcher dispatcher) {
+            StatusCodeSender sender, String accountId, SecureId requestId, Dispatcher dispatcher) {
         if ((storedSession == null)
                 || !requestId.equals(storedSession.verificationRequest().id())) {
             clearStoredVerificationData();
-            sender.sendError(418);
+            sender.sendErrorCode(418);
             return;
         }
 
@@ -82,7 +82,7 @@ final class FakeAvsService implements AvsApi {
         storedUser = users.get(accountId);
         if (storedUser == null) {
             clearStoredVerificationData();
-            sender.sendError(418);
+            sender.sendErrorCode(418);
             return;
         }
 
@@ -90,10 +90,11 @@ final class FakeAvsService implements AvsApi {
     }
 
     @Override
-    public void sendAgeCertificate(CodeSender sender, String accountId, AuthMatchData authData, Dispatcher dispatcher) {
+    public void sendAgeCertificate(
+            StatusCodeSender sender, String accountId, AuthMatchData authData, Dispatcher dispatcher) {
         if (!accountId.equals(storedAccountId)) {
             clearStoredVerificationData();
-            sender.sendError(418);
+            sender.sendErrorCode(418);
             return;
         }
 
@@ -134,7 +135,7 @@ final class FakeAvsService implements AvsApi {
     }
 
     /** Called when a response is received for the request to send a {@link SignedAgeCertificate} to a site. */
-    private void onAgeCertificateResponseReceived(Response response, CodeSender sender, Dispatcher dispatcher) {
+    private void onAgeCertificateResponseReceived(Response response, StatusCodeSender sender, Dispatcher dispatcher) {
         sender.send(response.code());
     }
 }


### PR DESCRIPTION
- `Sender`: `s/sendError()/sendErrorCode()/`
- `/s/CodeSender/StatusCodeSender/`