### PR TITLE
improved RequestDispatcher API

### DIFF
--- a/infra-service/build.gradle.kts
+++ b/infra-service/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     annotationProcessor("com.google.dagger:dagger-compiler")
 
     implementation(project(":api"))
+    implementation(project(":infra-api"))
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.google.dagger:dagger")
     implementation("com.squareup.okhttp3:okhttp")
@@ -16,7 +17,6 @@ dependencies {
     // test
     testAnnotationProcessor("com.google.dagger:dagger-compiler")
 
-    testImplementation(project(":infra-api"))
     testImplementation(testFixtures(project(":infra-api")))
     testImplementation(testFixtures(project(":testing-server")))
     testImplementation("com.squareup.okhttp3:mockwebserver")

--- a/infra-service/src/main/java/org/example/age/infra/service/client/RequestDispatcher.java
+++ b/infra-service/src/main/java/org/example/age/infra/service/client/RequestDispatcher.java
@@ -1,7 +1,7 @@
 package org.example.age.infra.service.client;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import okhttp3.Request;
+import okhttp3.HttpUrl;
 import org.example.age.api.Dispatcher;
 import org.example.age.api.Sender;
 
@@ -12,14 +12,25 @@ import org.example.age.api.Sender;
  */
 public interface RequestDispatcher {
 
-    /** Dispatches a request whose response does not have a body. */
-    <S extends Sender> void dispatch(Request request, S sender, Dispatcher dispatcher, ResponseCallback<S> callback);
+    /** Creates a builder for an exchange with the backend server at the specified URL. */
+    <S extends Sender> ExchangeBuilder<S> createExchangeBuilder(HttpUrl url, S sender, Dispatcher dispatcher);
 
-    /** Dispatches a request whose response has a body. */
-    <B, S extends Sender> void dispatch(
-            Request request,
-            TypeReference<B> responseBodyTypeRef,
-            S sender,
-            Dispatcher dispatcher,
-            ResponseBodyCallback<B, S> callback);
+    /** Builder for an exchange with the backend server. */
+    interface ExchangeBuilder<S extends Sender> {
+
+        /** Uses a GET request. */
+        ExchangeBuilder<S> get();
+
+        /** Uses a POST request without a request body. */
+        ExchangeBuilder<S> post();
+
+        /** Uses a POST request with a request body. */
+        ExchangeBuilder<S> post(Object requestBody);
+
+        /** Dispatches the request, expecting a response without a body. */
+        void dispatchWithoutResponseBody(ResponseCallback<S> callback);
+
+        /** Dispatches the request, expecting a response with a body. */
+        <B> void dispatchWithResponseBody(TypeReference<B> responseBodyTypeRef, ResponseBodyCallback<S, B> callback);
+    }
 }

--- a/infra-service/src/main/java/org/example/age/infra/service/client/RequestDispatcherImpl.java
+++ b/infra-service/src/main/java/org/example/age/infra/service/client/RequestDispatcherImpl.java
@@ -1,17 +1,18 @@
 package org.example.age.infra.service.client;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import okhttp3.Call;
 import okhttp3.Callback;
+import okhttp3.HttpUrl;
 import okhttp3.Request;
+import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.example.age.api.Dispatcher;
-import org.example.age.api.LiteHttpHandler;
+import org.example.age.api.HttpOptional;
+import org.example.age.api.JsonSerializer;
 import org.example.age.api.Sender;
 import org.example.age.infra.service.client.internal.ExchangeClient;
 
@@ -19,122 +20,164 @@ import org.example.age.infra.service.client.internal.ExchangeClient;
 final class RequestDispatcherImpl implements RequestDispatcher {
 
     private final ExchangeClient client;
-    private final ObjectMapper mapper;
+    private final JsonSerializer serializer;
 
     @Inject
-    public RequestDispatcherImpl(ExchangeClient client, ObjectMapper mapper) {
+    public RequestDispatcherImpl(ExchangeClient client, JsonSerializer serializer) {
         this.client = client;
-        this.mapper = mapper;
+        this.serializer = serializer;
     }
 
     @Override
-    public <S extends Sender> void dispatch(
-            Request request, S sender, Dispatcher dispatcher, ResponseCallback<S> callback) {
-        Call call = client.getInstance(dispatcher).newCall(request);
-        Callback adaptedCallback = new AdaptedResponseCallback<>(sender, dispatcher, callback);
-        call.enqueue(adaptedCallback);
-        dispatcher.dispatched();
+    public <S extends Sender> ExchangeBuilder<S> createExchangeBuilder(HttpUrl url, S sender, Dispatcher dispatcher) {
+        return new ExchangeBuilderImpl<>(url, sender, dispatcher);
     }
 
-    @Override
-    public <B, S extends Sender> void dispatch(
-            Request request,
-            TypeReference<B> responseBodyTypeRef,
-            S sender,
-            Dispatcher dispatcher,
-            ResponseBodyCallback<B, S> callback) {
-        Call call = client.getInstance(dispatcher).newCall(request);
-        Callback adaptedCallback =
-                new AdaptedResponseBodyCallback<>(mapper, responseBodyTypeRef, sender, dispatcher, callback);
-        call.enqueue(adaptedCallback);
-        dispatcher.dispatched();
-    }
+    /** {@link ExchangeBuilder} that builds the underlying {@link Request}. */
+    private final class ExchangeBuilderImpl<S extends Sender> implements ExchangeBuilder<S> {
 
-    /** Sends a 502 error when the request fails. */
-    private static void requestFailed(Sender sender) {
-        sender.sendErrorCode(502);
-    }
+        private static final RequestBody EMPTY_BODY = RequestBody.create(new byte[0]);
 
-    /** Adapts a {@link ResponseCallback} to a {@link Callback}. */
-    private record AdaptedResponseCallback<S extends Sender>(
-            S sender, Dispatcher dispatcher, ResponseCallback<S> callback) implements Callback {
+        private final Request.Builder requestBuilder;
+        private final S sender;
+        private final Dispatcher dispatcher;
 
-        @Override
-        public void onResponse(Call call, Response response) {
-            LiteHttpHandler<S> handler = new ResponseCallbackHandler<>(response, callback);
-            dispatcher.executeHandler(sender, handler);
+        public ExchangeBuilderImpl(HttpUrl url, S sender, Dispatcher dispatcher) {
+            requestBuilder = new Request.Builder().url(url);
+            this.sender = sender;
+            this.dispatcher = dispatcher;
         }
 
         @Override
-        public void onFailure(Call call, IOException e) {
-            requestFailed(sender);
+        public ExchangeBuilder<S> get() {
+            requestBuilder.get();
+            return this;
+        }
+
+        @Override
+        public ExchangeBuilder<S> post() {
+            requestBuilder.post(EMPTY_BODY);
+            return this;
+        }
+
+        @Override
+        public ExchangeBuilder<S> post(Object requestBody) {
+            byte[] rawRequestBody = serializer.serialize(requestBody);
+            requestBuilder.post(RequestBody.create(rawRequestBody));
+            return this;
+        }
+
+        @Override
+        public void dispatchWithoutResponseBody(ResponseCallback<S> callback) {
+            Callback adaptedCallback = new AdaptedResponseCallback<>(sender, dispatcher, callback);
+            dispatch(adaptedCallback);
+        }
+
+        @Override
+        public <B> void dispatchWithResponseBody(
+                TypeReference<B> responseBodyTypeRef, ResponseBodyCallback<S, B> callback) {
+            Callback adaptedCallback =
+                    new AdaptedResponseBodyCallback<>(sender, dispatcher, responseBodyTypeRef, callback);
+            dispatch(adaptedCallback);
+        }
+
+        /** Dispatches the request using a callback. */
+        private void dispatch(Callback callback) {
+            Request request = requestBuilder.build();
+            Call call = client.getInstance(dispatcher).newCall(request);
+            call.enqueue(callback);
+            dispatcher.dispatched();
+        }
+    }
+
+    /** Adapts a different type of callback to a {@link Callback}. */
+    private abstract static class AdaptedCallback<S extends Sender> implements Callback {
+
+        private final S sender;
+        private final Dispatcher dispatcher;
+
+        @Override
+        public final void onResponse(Call call, Response response) {
+            dispatcher.executeHandler(sender, (s, d) -> handleResponse(s, response, d));
+        }
+
+        @Override
+        public final void onFailure(Call call, IOException e) {
+            sender.sendErrorCode(502);
+        }
+
+        protected AdaptedCallback(S sender, Dispatcher dispatcher) {
+            this.sender = sender;
+            this.dispatcher = dispatcher;
+        }
+
+        /** Handles a {@link Response} that was received. */
+        protected abstract void handleResponse(S sender, Response response, Dispatcher dispatcher) throws Exception;
+    }
+
+    /** Adapts a {@link ResponseCallback} to a {@link Callback}. */
+    private static final class AdaptedResponseCallback<S extends Sender> extends AdaptedCallback<S> {
+
+        private final ResponseCallback<S> callback;
+
+        public AdaptedResponseCallback(S sender, Dispatcher dispatcher, ResponseCallback<S> callback) {
+            super(sender, dispatcher);
+            this.callback = callback;
+        }
+
+        @Override
+        protected void handleResponse(S sender, Response response, Dispatcher dispatcher) throws Exception {
+            callback.onResponse(sender, response, dispatcher);
         }
     }
 
     /** Adapts a {@link ResponseBodyCallback} to a {@link Callback}. */
-    private record AdaptedResponseBodyCallback<B, S extends Sender>(
-            ObjectMapper mapper,
-            TypeReference<B> responseBodyTypeRef,
-            S sender,
-            Dispatcher dispatcher,
-            ResponseBodyCallback<B, S> callback)
-            implements Callback {
+    private final class AdaptedResponseBodyCallback<S extends Sender, B> extends AdaptedCallback<S> {
 
-        @Override
-        public void onResponse(Call call, Response response) {
-            LiteHttpHandler<S> handler =
-                    new ResponseBodyCallbackHandler<>(response, mapper, responseBodyTypeRef, callback);
-            dispatcher.executeHandler(sender, handler);
+        private final TypeReference<B> responseBodyTypeRef;
+        private final ResponseBodyCallback<S, B> callback;
+
+        public AdaptedResponseBodyCallback(
+                S sender,
+                Dispatcher dispatcher,
+                TypeReference<B> responseBodyTypeRef,
+                ResponseBodyCallback<S, B> callback) {
+            super(sender, dispatcher);
+            this.responseBodyTypeRef = responseBodyTypeRef;
+            this.callback = callback;
         }
 
         @Override
-        public void onFailure(Call call, IOException e) {
-            requestFailed(sender);
-        }
-    }
-
-    /** {@link LiteHttpHandler} that calls a {@link ResponseCallback}. */
-    private record ResponseCallbackHandler<S extends Sender>(Response response, ResponseCallback<S> callback)
-            implements LiteHttpHandler<S> {
-
-        @Override
-        public void handleRequest(S sender, Dispatcher dispatcher) throws Exception {
-            callback.onResponse(response, sender, dispatcher);
-        }
-    }
-
-    /** {@link LiteHttpHandler} that calls a {@link ResponseBodyCallback}. */
-    private record ResponseBodyCallbackHandler<B, S extends Sender>(
-            Response response,
-            ObjectMapper mapper,
-            TypeReference<B> responseBodyTypeRef,
-            ResponseBodyCallback<B, S> callback)
-            implements LiteHttpHandler<S> {
-
-        @Override
-        public void handleRequest(S sender, Dispatcher dispatcher) throws Exception {
+        protected void handleResponse(S sender, Response response, Dispatcher dispatcher) throws Exception {
             if (!response.isSuccessful()) {
-                callback.onResponse(response, null, sender, dispatcher);
+                callback.onResponse(sender, response, null, dispatcher);
                 return;
             }
 
-            Optional<B> maybeResponseBody = tryParseResponseBody(response, sender);
+            HttpOptional<byte[]> maybeRawResponseBody = tryReadResponseBody(response);
+            if (maybeRawResponseBody.isEmpty()) {
+                sender.sendErrorCode(maybeRawResponseBody.statusCode());
+                return;
+            }
+            byte[] rawResponseBody = maybeRawResponseBody.get();
+
+            HttpOptional<B> maybeResponseBody = serializer.tryDeserialize(rawResponseBody, responseBodyTypeRef, 502);
             if (maybeResponseBody.isEmpty()) {
+                sender.sendErrorCode(maybeResponseBody.statusCode());
                 return;
             }
             B responseBody = maybeResponseBody.get();
 
-            callback.onResponse(response, responseBody, sender, dispatcher);
+            callback.onResponse(sender, response, responseBody, dispatcher);
         }
 
-        /** Parses the body from the response, or sends an error. */
-        private Optional<B> tryParseResponseBody(Response response, Sender sender) {
+        /** Reads the raw response body, or returns a 502 error. */
+        private static HttpOptional<byte[]> tryReadResponseBody(Response response) {
             try {
-                B responseBody = mapper.readValue(response.body().bytes(), responseBodyTypeRef);
-                return Optional.of(responseBody);
+                byte[] rawResponseBody = response.body().bytes();
+                return HttpOptional.of(rawResponseBody);
             } catch (IOException e) {
-                requestFailed(sender);
-                return Optional.empty();
+                return HttpOptional.empty(502);
             }
         }
     }

--- a/infra-service/src/main/java/org/example/age/infra/service/client/RequestDispatcherModule.java
+++ b/infra-service/src/main/java/org/example/age/infra/service/client/RequestDispatcherModule.java
@@ -3,6 +3,7 @@ package org.example.age.infra.service.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dagger.Binds;
 import dagger.Module;
+import org.example.age.infra.api.data.JsonSerializerModule;
 import org.example.age.infra.service.client.internal.ExchangeClientModule;
 
 /**
@@ -10,7 +11,7 @@ import org.example.age.infra.service.client.internal.ExchangeClientModule;
  *
  * <p>Depends on an unbound {@link ObjectMapper}.</p>
  */
-@Module(includes = ExchangeClientModule.class)
+@Module(includes = {ExchangeClientModule.class, JsonSerializerModule.class})
 public interface RequestDispatcherModule {
 
     @Binds

--- a/infra-service/src/main/java/org/example/age/infra/service/client/ResponseBodyCallback.java
+++ b/infra-service/src/main/java/org/example/age/infra/service/client/ResponseBodyCallback.java
@@ -10,7 +10,7 @@ import org.example.age.api.Sender;
  * <p>The body will be null if the response is not successful.</p>
  */
 @FunctionalInterface
-public interface ResponseBodyCallback<B, S extends Sender> {
+public interface ResponseBodyCallback<S extends Sender, B> {
 
-    void onResponse(Response response, B responseBody, S sender, Dispatcher dispatcher) throws Exception;
+    void onResponse(S sender, Response response, B responseBody, Dispatcher dispatcher) throws Exception;
 }

--- a/infra-service/src/main/java/org/example/age/infra/service/client/ResponseCallback.java
+++ b/infra-service/src/main/java/org/example/age/infra/service/client/ResponseCallback.java
@@ -8,5 +8,5 @@ import org.example.age.api.Sender;
 @FunctionalInterface
 public interface ResponseCallback<S extends Sender> {
 
-    void onResponse(Response response, S sender, Dispatcher dispatcher) throws Exception;
+    void onResponse(S sender, Response response, Dispatcher dispatcher) throws Exception;
 }


### PR DESCRIPTION
Fluent API that hides away serialization details (using `JsonSerializer`)

(Also changed argument order for callbacks to be consistent with `SiteApi`/`AvsApi`.)