### PR TITLE
resolve some pesky build issues

### DIFF
--- a/avs-api/build.gradle.kts
+++ b/avs-api/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 
 dependencies {
     // main
-    compileOnly("org.immutables:value-annotations")
     annotationProcessor("com.google.dagger:dagger-compiler")
     annotationProcessor("org.immutables:value")
 
@@ -20,6 +19,7 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp")
     implementation("io.undertow:undertow-core")
     implementation("javax.inject:javax.inject")
+    implementation("org.immutables:value-annotations")
 
     // test fixtures
     testFixturesAnnotationProcessor("com.google.dagger:dagger-compiler")

--- a/buildSrc/src/main/kotlin/org.example.age.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/org.example.age.java-conventions.gradle.kts
@@ -32,6 +32,7 @@ spotless {
 }
 
 tasks.withType<JavaCompile> {
+    // For -Xlint:classfile, see https://github.com/gradle/gradle/issues/27132
     options.compilerArgs.addAll(listOf("-Xlint:all,-classfile,-processing,-serial", "-Werror"))
     options.errorprone.disableWarningsInGeneratedCode.set(true)
 }

--- a/common-service/build.gradle.kts
+++ b/common-service/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 dependencies {
     // main
-    compileOnly("org.immutables:value-annotations")
     annotationProcessor("com.google.dagger:dagger-compiler")
     annotationProcessor("org.immutables:value")
 
@@ -18,9 +17,9 @@ dependencies {
     implementation("com.google.guava:guava")
     implementation("io.undertow:undertow-core")
     implementation("javax.inject:javax.inject")
+    implementation("org.immutables:value-annotations")
 
     // test
-    testCompileOnly("org.immutables:value-annotations")
     testAnnotationProcessor("com.google.dagger:dagger-compiler")
     testAnnotationProcessor("org.immutables:value")
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 dependencies {
     // main
-    compileOnly("org.immutables:value-annotations")
     annotationProcessor("com.google.dagger:dagger-compiler")
     annotationProcessor("org.immutables:value")
 
@@ -20,11 +19,11 @@ dependencies {
     implementation("com.google.guava:guava")
     implementation("io.undertow:undertow-core")
     implementation("javax.inject:javax.inject")
-
-    testCompileOnly("org.immutables:value-annotations")
-    testAnnotationProcessor("com.google.dagger:dagger-compiler")
+    implementation("org.immutables:value-annotations")
 
     // test
+    testAnnotationProcessor("com.google.dagger:dagger-compiler")
+
     testImplementation(project(":common-service"))
     testImplementation(testFixtures(project(":common-api")))
     testImplementation("org.mockito:mockito-core")

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 
 dependencies {
     // main
-    compileOnly("org.immutables:value-annotations")
     annotationProcessor("org.immutables:value")
 
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-guava")
     implementation("com.google.guava:guava")
+    implementation("org.immutables:value-annotations")
 
     // test
     testImplementation("com.google.guava:guava-testlib")

--- a/site-api/build.gradle.kts
+++ b/site-api/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 
 dependencies {
     // main
-    compileOnly("org.immutables:value-annotations")
     annotationProcessor("com.google.dagger:dagger-compiler")
     annotationProcessor("org.immutables:value")
 
@@ -20,6 +19,7 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp")
     implementation("io.undertow:undertow-core")
     implementation("javax.inject:javax.inject")
+    implementation("org.immutables:value-annotations")
 
     // test fixtures
     testFixturesAnnotationProcessor("com.google.dagger:dagger-compiler")

--- a/site-service/build.gradle.kts
+++ b/site-service/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 
 dependencies {
     // main
-    compileOnly("org.immutables:value-annotations")
     annotationProcessor("com.google.dagger:dagger-compiler")
     annotationProcessor("org.immutables:value")
 
@@ -22,6 +21,7 @@ dependencies {
     implementation("com.google.guava:guava")
     implementation("com.squareup.okhttp3:okhttp")
     implementation("javax.inject:javax.inject")
+    implementation("org.immutables:value-annotations")
     implementation("org.jboss.xnio:xnio-api")
 
     // test fixtures
@@ -40,7 +40,6 @@ dependencies {
     testFixturesImplementation("javax.inject:javax.inject")
 
     // test
-    testCompileOnly("org.immutables:value-annotations")
     testAnnotationProcessor("com.google.dagger:dagger-compiler")
 
     testImplementation(project(":avs-api"))


### PR DESCRIPTION
- Make `org.immutables:value-annotations` an `implementation` dependency.
    - Unlike `implementation`, `compileOnly` dependencies are not inherited by the `test` configuration.
    - When there's a missing `testCompileOnly` dependency, the error is not always easily traceable back to that root cause.
    - In short, `compileOnly` is a premature optimization (which is the root of all evil).
- Add a documentation note for `-Xlint:classfile`; tracked it down to a Gradle bug.