### PR TITLE
move FakeXnioExecutor to test fixtures for api module

### DIFF
--- a/api/src/test/java/org/example/age/testing/api/FakeXnioExecutorTest.java
+++ b/api/src/test/java/org/example/age/testing/api/FakeXnioExecutorTest.java
@@ -1,0 +1,78 @@
+package org.example.age.testing.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xnio.XnioExecutor;
+
+public final class FakeXnioExecutorTest {
+
+    private FakeXnioExecutor executor;
+
+    private Runnable command;
+    private boolean commandWasRun;
+
+    @BeforeEach
+    public void createFakeXnioExecutorEtAl() {
+        executor = FakeXnioExecutor.create();
+        command = () -> commandWasRun = true;
+        commandWasRun = false;
+    }
+
+    @Test
+    public void execute() {
+        executor.execute(command);
+        assertThat(commandWasRun).isTrue();
+    }
+
+    @Test
+    public void executeAfter() {
+        executor.executeAfter(command, 1, TimeUnit.SECONDS);
+        assertThat(commandWasRun).isFalse();
+
+        FakeXnioExecutor.ScheduledTask scheduledTask = executor.getLastScheduledTask();
+        assertThat(scheduledTask.getTime()).isEqualTo(1L);
+        assertThat(scheduledTask.getUnit()).isEqualTo(TimeUnit.SECONDS);
+        scheduledTask.run();
+        assertThat(commandWasRun).isTrue();
+    }
+
+    @Test
+    public void executeAtInterval() {
+        executor.executeAtInterval(command, 1, TimeUnit.SECONDS);
+        assertThat(commandWasRun).isFalse();
+
+        FakeXnioExecutor.ScheduledTask scheduledTask = executor.getLastScheduledTask();
+        assertThat(scheduledTask.getTime()).isEqualTo(1L);
+        assertThat(scheduledTask.getUnit()).isEqualTo(TimeUnit.SECONDS);
+        scheduledTask.run();
+        assertThat(commandWasRun).isTrue();
+    }
+
+    @Test
+    public void remove() {
+        XnioExecutor.Key key = executor.executeAfter(command, 1, TimeUnit.SECONDS);
+        boolean wasRemoved = key.remove();
+        assertThat(wasRemoved).isTrue();
+
+        FakeXnioExecutor.ScheduledTask scheduledTask = executor.getLastScheduledTask();
+        scheduledTask.run();
+        assertThat(commandWasRun).isFalse();
+
+        boolean wasRemovedAgain = key.remove();
+        assertThat(wasRemovedAgain).isFalse();
+    }
+
+    @Test
+    public void runAndRemove() {
+        XnioExecutor.Key key = executor.executeAfter(command, 1, TimeUnit.SECONDS);
+        FakeXnioExecutor.ScheduledTask scheduledTask = executor.getLastScheduledTask();
+        scheduledTask.run();
+        assertThat(commandWasRun).isTrue();
+
+        boolean wasRemoved = key.remove();
+        assertThat(wasRemoved).isFalse();
+    }
+}

--- a/api/src/testFixtures/java/org/example/age/testing/api/FakeXnioExecutor.java
+++ b/api/src/testFixtures/java/org/example/age/testing/api/FakeXnioExecutor.java
@@ -1,9 +1,9 @@
-package org.example.age.common.service.store.testing;
+package org.example.age.testing.api;
 
 import java.util.concurrent.TimeUnit;
 import org.xnio.XnioExecutor;
 
-/** Fake {@link XnioExecutor} where scheduled tasks have to be run manually. */
+/** Fake same-thread {@link XnioExecutor} where scheduled tasks have to be run manually. */
 public final class FakeXnioExecutor implements XnioExecutor {
 
     private ScheduledTask lastScheduledTask = null;
@@ -12,6 +12,7 @@ public final class FakeXnioExecutor implements XnioExecutor {
         return new FakeXnioExecutor();
     }
 
+    /** Gets the last scheduled task. */
     public ScheduledTask getLastScheduledTask() {
         if (lastScheduledTask == null) {
             throw new IllegalStateException();
@@ -22,7 +23,7 @@ public final class FakeXnioExecutor implements XnioExecutor {
 
     @Override
     public void execute(Runnable command) {
-        throw new UnsupportedOperationException();
+        command.run();
     }
 
     @Override
@@ -33,7 +34,8 @@ public final class FakeXnioExecutor implements XnioExecutor {
 
     @Override
     public Key executeAtInterval(Runnable command, long time, TimeUnit unit) {
-        throw new UnsupportedOperationException();
+        lastScheduledTask = new ScheduledTask(command, time, unit);
+        return lastScheduledTask;
     }
 
     private FakeXnioExecutor() {}
@@ -47,10 +49,12 @@ public final class FakeXnioExecutor implements XnioExecutor {
 
         private boolean wasRemoved = false;
 
+        /** Gets the scheduled time. */
         public long getTime() {
             return time;
         }
 
+        /** Gets the scheduled unit. */
         public TimeUnit getUnit() {
             return unit;
         }

--- a/common-service/src/test/java/org/example/age/common/service/store/InMemoryPendingStoreFactoryTest.java
+++ b/common-service/src/test/java/org/example/age/common/service/store/InMemoryPendingStoreFactoryTest.java
@@ -9,8 +9,8 @@ import dagger.Module;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Singleton;
 import org.assertj.core.data.Offset;
-import org.example.age.common.service.store.testing.FakeXnioExecutor;
 import org.example.age.test.data.TestMapperModule;
+import org.example.age.testing.api.FakeXnioExecutor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -78,6 +78,16 @@ public final class InMemoryPendingStoreFactoryTest {
     public void tryRemoveEmptyValue() {
         PendingStore<String> store = storeFactory.getOrCreate("name", new TypeReference<>() {});
         assertThat(store.tryRemove("key")).isEmpty();
+    }
+
+    @Test
+    public void putTwoKeysWithSameValue() {
+        PendingStore<String> store = storeFactory.getOrCreate("name", new TypeReference<>() {});
+        long expiration = createExpiration();
+        store.put("key1", "value", expiration, executor);
+        store.put("key2", "value", expiration, executor);
+        assertThat(store.tryGet("key1")).hasValue("value");
+        assertThat(store.tryGet("key2")).hasValue("value");
     }
 
     @Test


### PR DESCRIPTION
also add tests for `FakeXnioExecutor` (and an unrelated additional test for `InMemoryPendingStoreFactory`)