### PR TITLE
fix performance issue in build.yml configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,9 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-          cache: gradle
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2.9.0
+        uses: gradle/gradle-build-action@v2.10.0
 
       - name: Build
         run: ./gradlew build


### PR DESCRIPTION
Should not use `cache: gradle` in `setup-java` when `gradle-build-action` is also used; `gradle-build-action` has its own caching mechanism. See: https://github.com/gradle/gradle-build-action#incompatibility-with-other-caching-mechanisms

(Also bump `gradle-build-action` version.)