### PR TITLE
host and port as separate methods

### DIFF
--- a/common-data/src/main/java/org/example/age/common/service/data/AvsLocation.java
+++ b/common-data/src/main/java/org/example/age/common/service/data/AvsLocation.java
@@ -2,7 +2,6 @@ package org.example.age.common.service.data;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.net.HostAndPort;
 import okhttp3.HttpUrl;
 import org.example.age.data.crypto.SecureId;
 import org.example.age.data.utils.DataStyle;
@@ -21,16 +20,14 @@ public interface AvsLocation {
 
     /** Creates a builder for the location. */
     static Builder builder(String host, int port) {
-        return builder(HostAndPort.fromParts(host, port));
+        return new Builder().host(host).port(port);
     }
 
-    /** Creates a builder for the location. */
-    static Builder builder(HostAndPort hostAndPort) {
-        return new Builder().hostAndPort(hostAndPort);
-    }
+    /** Host of the age verification service. */
+    String host();
 
-    /** Host and port of the age verification service. */
-    HostAndPort hostAndPort();
+    /** Port of the age verification service. */
+    int port();
 
     /** Path of the API to create a verification session. */
     @Value.Default
@@ -46,8 +43,8 @@ public interface AvsLocation {
     default HttpUrl verificationSessionUrl(String siteId) {
         return new HttpUrl.Builder()
                 .scheme("http")
-                .host(hostAndPort().getHost())
-                .port(hostAndPort().getPort())
+                .host(host())
+                .port(port())
                 .addPathSegments(verificationSessionPath())
                 .addQueryParameter("site-id", siteId)
                 .build();
@@ -58,8 +55,8 @@ public interface AvsLocation {
     default HttpUrl redirectUrl(SecureId requestId) {
         return new HttpUrl.Builder()
                 .scheme("http")
-                .host(hostAndPort().getHost())
-                .port(hostAndPort().getPort())
+                .host(host())
+                .port(port())
                 .addPathSegments(redirectPath())
                 .addQueryParameter("request-id", requestId.toString())
                 .build();

--- a/common-data/src/main/java/org/example/age/common/service/data/SiteLocation.java
+++ b/common-data/src/main/java/org/example/age/common/service/data/SiteLocation.java
@@ -3,7 +3,6 @@ package org.example.age.common.service.data;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.net.HostAndPort;
 import okhttp3.HttpUrl;
 import org.example.age.data.utils.DataStyle;
 import org.immutables.value.Value;
@@ -20,17 +19,15 @@ import org.immutables.value.Value;
 public interface SiteLocation {
 
     /** Creates a builder for the location. */
-    static Builder builder(String host, int port) {
-        return builder(HostAndPort.fromParts(host, port));
+    static SiteLocation.Builder builder(String host, int port) {
+        return new Builder().host(host).port(port);
     }
 
-    /** Creates a builder for the location. */
-    static Builder builder(HostAndPort hostAndPort) {
-        return new Builder().hostAndPort(hostAndPort);
-    }
+    /** Host of the site. */
+    String host();
 
-    /** Host and port of the site. */
-    HostAndPort hostAndPort();
+    /** Port of the site. */
+    int port();
 
     /** Path of the API to process an age certificate. */
     @Value.Default
@@ -47,8 +44,8 @@ public interface SiteLocation {
     default HttpUrl ageCertificateUrl() {
         return new HttpUrl.Builder()
                 .scheme("http")
-                .host(hostAndPort().getHost())
-                .port(hostAndPort().getPort())
+                .host(host())
+                .port(port())
                 .addPathSegments(ageCertificatePath())
                 .build();
     }
@@ -59,8 +56,8 @@ public interface SiteLocation {
     default HttpUrl redirectUrl() {
         return new HttpUrl.Builder()
                 .scheme("http")
-                .host(hostAndPort().getHost())
-                .port(hostAndPort().getPort())
+                .host(host())
+                .port(port())
                 .addPathSegments(redirectPath())
                 .build();
     }

--- a/common-data/src/testFixtures/java/org/example/age/test/common/service/data/TestLocations.java
+++ b/common-data/src/testFixtures/java/org/example/age/test/common/service/data/TestLocations.java
@@ -9,14 +9,14 @@ final class TestLocations {
 
     /** Gets the {@link AvsLocation} from the corresponding {@link TestServer}. */
     public static AvsLocation avs(TestServer<?> avsServer) {
-        return AvsLocation.builder(avsServer.hostAndPort())
+        return AvsLocation.builder(avsServer.host(), avsServer.port())
                 .redirectPath("verify")
                 .build();
     }
 
     /** Gets the {@link SiteLocation} from the corresponding {@link TestServer}. */
     public static SiteLocation site(TestServer<?> siteServer) {
-        return SiteLocation.builder(siteServer.hostAndPort())
+        return SiteLocation.builder(siteServer.host(), siteServer.port())
                 .redirectPath("verify")
                 .build();
     }

--- a/testing-server/build.gradle.kts
+++ b/testing-server/build.gradle.kts
@@ -7,7 +7,6 @@ dependencies {
     // test fixtures
     testFixturesApi("com.fasterxml.jackson.core:jackson-databind")
     testFixturesApi("com.fasterxml.jackson.datatype:jackson-datatype-guava")
-    testFixturesApi("com.google.guava:guava")
     testFixturesApi("com.squareup.okhttp3:mockwebserver")
     testFixturesApi("com.squareup.okhttp3:okhttp")
     testFixturesApi("io.undertow:undertow-core")

--- a/testing-server/src/test/java/org/example/age/testing/server/MockServerTest.java
+++ b/testing-server/src/test/java/org/example/age/testing/server/MockServerTest.java
@@ -31,9 +31,8 @@ public final class MockServerTest {
 
     @Test
     public void getLocation() {
-        assertThat(server.hostAndPort().getHost()).isEqualTo("localhost");
-        String expectedUrl =
-                String.format("http://localhost:%d", server.hostAndPort().getPort());
+        assertThat(server.host()).isEqualTo("localhost");
+        String expectedUrl = String.format("http://localhost:%d", server.port());
         assertThat(server.rootUrl()).isEqualTo(expectedUrl);
     }
 
@@ -41,7 +40,8 @@ public final class MockServerTest {
     public void error_ServerNotStarted() {
         MockServer inactiveServer = MockServer.create();
         error_ServerNotStarted(inactiveServer::get);
-        error_ServerNotStarted(inactiveServer::hostAndPort);
+        error_ServerNotStarted(inactiveServer::host);
+        error_ServerNotStarted(inactiveServer::port);
         error_ServerNotStarted(inactiveServer::rootUrl);
         error_ServerNotStarted(() -> inactiveServer.enqueue(new MockResponse()));
     }

--- a/testing-server/src/test/java/org/example/age/testing/server/TestServerTest.java
+++ b/testing-server/src/test/java/org/example/age/testing/server/TestServerTest.java
@@ -2,14 +2,13 @@ package org.example.age.testing.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.net.HostAndPort;
 import org.junit.jupiter.api.Test;
 
 public class TestServerTest {
 
     @Test
     public void url() {
-        StubServer server = StubServer.create();
+        TestServer<?> server = StubServer.create();
         String expectedUrl = "http://localhost/path";
         assertThat(server.url("/path")).isEqualTo(expectedUrl);
         assertThat(server.url("path")).isEqualTo(expectedUrl);
@@ -17,14 +16,14 @@ public class TestServerTest {
 
     @Test
     public void url_Format() {
-        StubServer server = StubServer.create();
+        TestServer<?> server = StubServer.create();
         assertThat(server.url("/path?name=%s", "value")).isEqualTo("http://localhost/path?name=value");
     }
 
     /** Stub test server with a root URL. */
     private static final class StubServer implements TestServer<Void> {
 
-        public static StubServer create() {
+        public static TestServer<?> create() {
             return new StubServer();
         }
 
@@ -34,7 +33,12 @@ public class TestServerTest {
         }
 
         @Override
-        public HostAndPort hostAndPort() {
+        public String host() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int port() {
             throw new UnsupportedOperationException();
         }
 

--- a/testing-server/src/test/java/org/example/age/testing/server/TestUndertowServerTest.java
+++ b/testing-server/src/test/java/org/example/age/testing/server/TestUndertowServerTest.java
@@ -37,10 +37,9 @@ public final class TestUndertowServerTest {
 
     @Test
     public void getLocation() {
-        assertThat(server.hostAndPort().getHost()).isEqualTo("localhost");
-        assertThat(server.hostAndPort().getPort()).isBetween(1024, 65535);
-        String expectedUrl =
-                String.format("http://localhost:%d", server.hostAndPort().getPort());
+        assertThat(server.host()).isEqualTo("localhost");
+        assertThat(server.port()).isBetween(1024, 65535);
+        String expectedUrl = String.format("http://localhost:%d", server.port());
         assertThat(server.rootUrl()).isEqualTo(expectedUrl);
     }
 
@@ -48,7 +47,8 @@ public final class TestUndertowServerTest {
     public void error_ServerNotStarted() {
         TestUndertowServer inactiveServer = TestUndertowServer.fromHandler(() -> TestUndertowServerTest::stubHandle);
         error_ServerNotStarted(inactiveServer::get);
-        error_ServerNotStarted(inactiveServer::hostAndPort);
+        error_ServerNotStarted(inactiveServer::host);
+        error_ServerNotStarted(inactiveServer::port);
         error_ServerNotStarted(inactiveServer::rootUrl);
     }
 

--- a/testing-server/src/testFixtures/java/org/example/age/testing/server/MockServer.java
+++ b/testing-server/src/testFixtures/java/org/example/age/testing/server/MockServer.java
@@ -1,6 +1,5 @@
 package org.example.age.testing.server;
 
-import com.google.common.net.HostAndPort;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -15,7 +14,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 public final class MockServer implements TestServer<MockWebServer>, BeforeEachCallback, AfterEachCallback {
 
     private MockWebServer server = null;
-    private HostAndPort hostAndPort = null;
     private String rootUrl = null;
 
     /** Creates a mock server. */
@@ -30,9 +28,15 @@ public final class MockServer implements TestServer<MockWebServer>, BeforeEachCa
     }
 
     @Override
-    public HostAndPort hostAndPort() {
+    public String host() {
         checkServerStarted();
-        return hostAndPort;
+        return server.getHostName();
+    }
+
+    @Override
+    public int port() {
+        checkServerStarted();
+        return server.getPort();
     }
 
     @Override
@@ -51,7 +55,6 @@ public final class MockServer implements TestServer<MockWebServer>, BeforeEachCa
     public void beforeEach(ExtensionContext extensionContext) throws Exception {
         server = new MockWebServer();
         server.start();
-        hostAndPort = HostAndPort.fromParts(server.getHostName(), server.getPort());
         rootUrl = String.format("http://%s:%d", server.getHostName(), server.getPort());
     }
 
@@ -62,7 +65,6 @@ public final class MockServer implements TestServer<MockWebServer>, BeforeEachCa
         }
 
         server = null;
-        hostAndPort = null;
         rootUrl = null;
     }
 

--- a/testing-server/src/testFixtures/java/org/example/age/testing/server/TestServer.java
+++ b/testing-server/src/testFixtures/java/org/example/age/testing/server/TestServer.java
@@ -1,6 +1,5 @@
 package org.example.age.testing.server;
 
-import com.google.common.net.HostAndPort;
 import com.google.errorprone.annotations.FormatMethod;
 
 /**
@@ -13,8 +12,11 @@ public interface TestServer<T> {
     /** Gets the underlying server. */
     T get();
 
-    /** Gets the host and port of the server. */
-    HostAndPort hostAndPort();
+    /** Gets the host of the server. */
+    String host();
+
+    /** Gets the port of the server. */
+    int port();
 
     /** Gets the root URL for the server. */
     String rootUrl();
@@ -28,8 +30,8 @@ public interface TestServer<T> {
     /** Gets the URL at the provided path. */
     @FormatMethod
     default String url(String pathFormat, Object... args) {
-        pathFormat = pathFormat.startsWith("/") ? pathFormat : String.format("/%s", pathFormat);
+        pathFormat = pathFormat.replaceFirst("^/", "");
         String path = String.format(pathFormat, args);
-        return String.format("%s%s", rootUrl(), path);
+        return String.format("%s/%s", rootUrl(), path);
     }
 }

--- a/testing-server/src/testFixtures/java/org/example/age/testing/server/TestUndertowServer.java
+++ b/testing-server/src/testFixtures/java/org/example/age/testing/server/TestUndertowServer.java
@@ -1,6 +1,5 @@
 package org.example.age.testing.server;
 
-import com.google.common.net.HostAndPort;
 import io.undertow.Undertow;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.handlers.PathHandler;
@@ -27,7 +26,7 @@ public final class TestUndertowServer implements TestServer<Undertow>, BeforeAll
     private final TestUndertowFactory serverFactory;
 
     private Undertow server = null;
-    private HostAndPort hostAndPort = null;
+    private int port = 0;
     private String rootUrl = null;
 
     /** Creates a test server from a root {@link HttpHandler}, which is created by a factory. */
@@ -56,9 +55,15 @@ public final class TestUndertowServer implements TestServer<Undertow>, BeforeAll
     }
 
     @Override
-    public HostAndPort hostAndPort() {
+    public String host() {
         checkServerStarted();
-        return hostAndPort;
+        return "localhost";
+    }
+
+    @Override
+    public int port() {
+        checkServerStarted();
+        return port;
     }
 
     @Override
@@ -89,7 +94,7 @@ public final class TestUndertowServer implements TestServer<Undertow>, BeforeAll
         }
 
         server = null;
-        hostAndPort = null;
+        port = 0;
         rootUrl = null;
     }
 
@@ -112,11 +117,10 @@ public final class TestUndertowServer implements TestServer<Undertow>, BeforeAll
 
     /** Starts the server. */
     private void startServer() {
-        int port = RANDOM.nextInt(1024, 65536);
+        port = RANDOM.nextInt(1024, 65536);
+        rootUrl = String.format("http://localhost:%d", port);
         server = serverFactory.create(port);
         server.start();
-        hostAndPort = HostAndPort.fromParts("localhost", port);
-        rootUrl = String.format("http://localhost:%d", port);
     }
 
     /** Gets the message and stack trace as text. */


### PR DESCRIPTION
It's simpler and cleaner, and it's one less dep.

(Probably was some legacy reason to use `HostAndPort`, but it's long since gone.)