### PR TITLE
adjust immutable style (and work around warning)

### DIFF
--- a/buildSrc/src/main/kotlin/org.example.age.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/org.example.age.java-conventions.gradle.kts
@@ -32,9 +32,7 @@ spotless {
 }
 
 tasks.withType<JavaCompile> {
-    // For -Xlint:classfile, see https://github.com/gradle/gradle/issues/27132
-    // For -Xlint:cast, see https://github.com/immutables/immutables/issues/1491
-    options.compilerArgs.addAll(listOf("-Xlint:all,-cast,-classfile,-processing,-serial", "-Werror"))
+    options.compilerArgs.addAll(listOf("-Xlint:all,-processing,-serial", "-Werror"))
     options.errorprone.disableWarningsInGeneratedCode.set(true)
 }
 

--- a/core/data/src/main/java/org/example/age/data/utils/DataStyle.java
+++ b/core/data/src/main/java/org/example/age/data/utils/DataStyle.java
@@ -2,9 +2,15 @@ package org.example.age.data.utils;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
+import javax.annotation.processing.Generated;
 import org.immutables.value.Value;
 
 /** Style to apply to immutable data types. */
+@Value.Style(
+        visibility = Value.Style.ImplementationVisibility.PACKAGE,
+        overshadowImplementation = true,
+        defaults = @Value.Immutable(copy = false),
+        from = "",
+        allowedClasspathAnnotations = {Generated.class, org.immutables.value.Generated.class})
 @Target(ElementType.TYPE)
-@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
 public @interface DataStyle {}


### PR DESCRIPTION
- `overshadowImplementation = true` will make the `cast` warning go away.
- `classfile` warning was already fixed; re-enable that warning as well.