### PR TITLE
rewire :core:site:service test fixtures

### DIFF
--- a/core/site/service/build.gradle.kts
+++ b/core/site/service/build.gradle.kts
@@ -26,18 +26,29 @@ dependencies {
     // test fixtures
     testFixturesAnnotationProcessor("com.google.dagger:dagger-compiler")
 
+    testFixturesApi(project(":core:common:api-types"))
+    testFixturesApi(project(":core:data"))
+    testFixturesApi("com.google.dagger:dagger")
+    testFixturesApi("javax.inject:javax.inject")
+    testFixturesApi("io.undertow:undertow-core")
+
+    testFixturesImplementation(project(":api-types"))
     testFixturesApi(project(":core:avs:api"))
+    testFixturesImplementation(project(":core:common:service-types"))
+    testFixturesApi(project(":core:common:service"))
+    testFixturesApi(project(":infra:service"))
     testFixturesApi(testFixtures(project(":module:config:common:test")))
     testFixturesApi(testFixtures(project(":module:config:site:test")))
     testFixturesApi(project(":module:extractor:common:builtin"))
     testFixturesApi(testFixtures(project(":module:extractor:common:builtin")))
     testFixturesApi(testFixtures(project(":module:key:common:test")))
     testFixturesApi(project(":module:store:common:inmemory"))
-    testFixturesApi(testFixtures(project(":testing")))
+    testFixturesImplementation("com.fasterxml.jackson.core:jackson-databind")
 
     // test
     testAnnotationProcessor("com.google.dagger:dagger-compiler")
 
     testImplementation(testFixtures(project(":api-types")))
     testImplementation(testFixtures(project(":testing")))
+    testImplementation("io.undertow:undertow-core")
 }

--- a/core/site/service/src/main/java/org/example/age/site/service/endpoint/SiteServiceModule.java
+++ b/core/site/service/src/main/java/org/example/age/site/service/endpoint/SiteServiceModule.java
@@ -2,6 +2,7 @@ package org.example.age.site.service.endpoint;
 
 import dagger.Binds;
 import dagger.Module;
+import io.undertow.server.HttpHandler;
 import java.security.PublicKey;
 import org.example.age.common.api.extractor.AccountIdExtractor;
 import org.example.age.common.api.extractor.AuthMatchDataExtractor;
@@ -16,7 +17,7 @@ import org.example.age.site.service.store.VerificationStore;
 import org.example.age.site.service.verification.internal.SiteVerificationManagerModule;
 
 /**
- * Dagger module that binds dependencies for <code>@Named("api") HttpHandler</code>.
+ * Dagger module that binds dependencies for <code>@Named("api") {@link HttpHandler}</code>.
  *
  * <p>Depends on an unbound...</p>
  * <ul>

--- a/core/site/service/src/test/java/org/example/age/site/service/endpoint/SiteServiceTest.java
+++ b/core/site/service/src/test/java/org/example/age/site/service/endpoint/SiteServiceTest.java
@@ -6,22 +6,16 @@ import static org.example.age.testing.api.HttpOptionalAssert.assertThat;
 import com.fasterxml.jackson.core.type.TypeReference;
 import dagger.BindsInstance;
 import dagger.Component;
-import dagger.Module;
 import io.undertow.server.HttpHandler;
 import java.io.IOException;
 import java.util.Map;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import org.example.age.api.HttpOptional;
-import org.example.age.avs.service.endpoint.test.FakeAvsServiceModule;
-import org.example.age.common.api.extractor.builtin.DisabledAuthMatchDataExtractorModule;
-import org.example.age.common.api.extractor.test.TestAccountIdExtractorModule;
-import org.example.age.common.service.key.test.TestKeyModule;
-import org.example.age.common.service.store.inmemory.InMemoryPendingStoreFactoryModule;
+import org.example.age.avs.service.endpoint.test.TestAvsServiceModule;
 import org.example.age.data.certificate.VerificationSession;
 import org.example.age.data.crypto.SecureId;
-import org.example.age.site.service.config.test.TestSiteConfigModule;
-import org.example.age.site.service.store.InMemoryVerificationStoreModule;
+import org.example.age.site.service.endpoint.test.TestSiteServiceModule;
 import org.example.age.testing.client.TestClient;
 import org.example.age.testing.server.TestServer;
 import org.example.age.testing.server.TestUndertowServer;
@@ -71,21 +65,8 @@ public final class SiteServiceTest {
         assertThat(certificateStatusCode).isEqualTo(expectedStatusCode);
     }
 
-    /** Dagger module that binds dependencies for <code>@Named("api") {@link HttpHandler}</code>. */
-    @Module(
-            includes = {
-                SiteServiceModule.class,
-                TestAccountIdExtractorModule.class,
-                DisabledAuthMatchDataExtractorModule.class,
-                InMemoryVerificationStoreModule.class,
-                InMemoryPendingStoreFactoryModule.class,
-                TestKeyModule.class,
-                TestSiteConfigModule.class,
-            })
-    interface TestModule {}
-
     /** Dagger components that provides an {@link HttpHandler}. */
-    @Component(modules = TestModule.class)
+    @Component(modules = TestSiteServiceModule.class)
     @Singleton
     interface TestComponent {
 
@@ -106,7 +87,7 @@ public final class SiteServiceTest {
     }
 
     /** Dagger components that provides an {@link HttpHandler}. */
-    @Component(modules = FakeAvsServiceModule.class)
+    @Component(modules = TestAvsServiceModule.class)
     @Singleton
     interface FakeAvsComponent {
 

--- a/core/site/service/src/testFixtures/java/org/example/age/avs/service/data/internal/AvsServiceJsonSerializerModule.java
+++ b/core/site/service/src/testFixtures/java/org/example/age/avs/service/data/internal/AvsServiceJsonSerializerModule.java
@@ -1,4 +1,4 @@
-package org.example.age.site.service.data.internal;
+package org.example.age.avs.service.data.internal;
 
 import dagger.Module;
 import dagger.Provides;
@@ -9,7 +9,7 @@ import org.example.age.data.mapper.DataMapper;
 
 /** Dagger module that publishes a binding for <code>@Named("service") {@link JsonSerializer}</code>. */
 @Module
-public interface SiteServiceJsonSerializerModule {
+public interface AvsServiceJsonSerializerModule {
 
     @Provides
     @Named("service")

--- a/core/site/service/src/testFixtures/java/org/example/age/avs/service/endpoint/FakeAvsService.java
+++ b/core/site/service/src/testFixtures/java/org/example/age/avs/service/endpoint/FakeAvsService.java
@@ -1,4 +1,4 @@
-package org.example.age.avs.service.endpoint.test;
+package org.example.age.avs.service.endpoint;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -21,8 +21,8 @@ import org.example.age.infra.service.client.RequestDispatcher;
 final class FakeAvsService implements AvsApi {
 
     private final FakeAvsVerificationFactory verificationFactory;
-    private final RequestDispatcher requestDispatcher;
     private final Provider<SiteLocation> siteLocationProvider;
+    private final RequestDispatcher requestDispatcher;
 
     private VerificationSession storedSession = null;
     private String storedAccountId = null;
@@ -30,11 +30,11 @@ final class FakeAvsService implements AvsApi {
     @Inject
     public FakeAvsService(
             FakeAvsVerificationFactory verificationFactory,
-            RequestDispatcher requestDispatcher,
-            Provider<SiteLocation> siteLocationProvider) {
+            Provider<SiteLocation> siteLocationProvider,
+            RequestDispatcher requestDispatcher) {
         this.verificationFactory = verificationFactory;
-        this.requestDispatcher = requestDispatcher;
         this.siteLocationProvider = siteLocationProvider;
+        this.requestDispatcher = requestDispatcher;
     }
 
     @Override

--- a/core/site/service/src/testFixtures/java/org/example/age/avs/service/endpoint/FakeAvsServiceModule.java
+++ b/core/site/service/src/testFixtures/java/org/example/age/avs/service/endpoint/FakeAvsServiceModule.java
@@ -1,0 +1,38 @@
+package org.example.age.avs.service.endpoint;
+
+import dagger.Binds;
+import dagger.Module;
+import io.undertow.server.HttpHandler;
+import java.security.PrivateKey;
+import org.example.age.avs.api.endpoint.AvsApi;
+import org.example.age.avs.api.endpoint.AvsApiModule;
+import org.example.age.avs.service.data.internal.AvsServiceJsonSerializerModule;
+import org.example.age.avs.service.verification.internal.FakeAvsVerificationFactoryModule;
+import org.example.age.common.api.extractor.AccountIdExtractor;
+import org.example.age.common.api.extractor.AuthMatchDataExtractor;
+import org.example.age.common.service.config.SiteLocation;
+import org.example.age.infra.service.client.RequestDispatcherModule;
+
+/**
+ * Dagger module that binds dependencies for <code>@Named("api") {@link HttpHandler}</code>.
+ *
+ * <p>Depends on an unbound...</p>
+ * <ul>
+ *     <li>{@link AccountIdExtractor}</li>
+ *     <li>{@link AuthMatchDataExtractor}</li>
+ *     <li><code>@Named("signing") Provider&lt;{@link PrivateKey}&gt;</code></li>
+ *     <li><code>Provider&lt;{@link SiteLocation}&gt;</code></li>
+ * </ul>
+ */
+@Module(
+        includes = {
+            AvsApiModule.class,
+            FakeAvsVerificationFactoryModule.class,
+            RequestDispatcherModule.class,
+            AvsServiceJsonSerializerModule.class,
+        })
+public interface FakeAvsServiceModule {
+
+    @Binds
+    AvsApi bindAvsApi(FakeAvsService service);
+}

--- a/core/site/service/src/testFixtures/java/org/example/age/avs/service/endpoint/test/TestAvsServiceModule.java
+++ b/core/site/service/src/testFixtures/java/org/example/age/avs/service/endpoint/test/TestAvsServiceModule.java
@@ -1,32 +1,25 @@
 package org.example.age.avs.service.endpoint.test;
 
-import dagger.Binds;
 import dagger.Module;
-import org.example.age.avs.api.endpoint.AvsApi;
-import org.example.age.avs.api.endpoint.AvsApiModule;
-import org.example.age.avs.service.verification.internal.FakeAvsVerificationFactoryModule;
+import io.undertow.server.HttpHandler;
+import org.example.age.avs.service.endpoint.FakeAvsServiceModule;
 import org.example.age.common.api.extractor.builtin.DisabledAuthMatchDataExtractorModule;
 import org.example.age.common.api.extractor.test.TestAccountIdExtractorModule;
 import org.example.age.common.service.config.test.TestSiteLocationModule;
-import org.example.age.infra.service.client.RequestDispatcherModule;
+import org.example.age.common.service.key.test.TestKeyModule;
 import org.example.age.testing.server.TestServer;
 
 /**
- * Dagger module that binds dependencies for <code>@Named("api") HttpHandler</code>.
+ * Dagger module that binds dependencies for <code>@Named("api") {@link HttpHandler}</code>.
  *
  * <p>Depends on an unbound <code>@Named("site") {@link TestServer}&lt?&gt;</code>.</p>
  */
 @Module(
         includes = {
-            AvsApiModule.class,
+            FakeAvsServiceModule.class,
             TestAccountIdExtractorModule.class,
             DisabledAuthMatchDataExtractorModule.class,
-            FakeAvsVerificationFactoryModule.class,
-            RequestDispatcherModule.class,
+            TestKeyModule.class,
             TestSiteLocationModule.class,
         })
-public interface FakeAvsServiceModule {
-
-    @Binds
-    AvsApi bindAvsApi(FakeAvsService service);
-}
+public interface TestAvsServiceModule {}

--- a/core/site/service/src/testFixtures/java/org/example/age/avs/service/verification/internal/FakeAvsVerificationFactoryModule.java
+++ b/core/site/service/src/testFixtures/java/org/example/age/avs/service/verification/internal/FakeAvsVerificationFactoryModule.java
@@ -1,25 +1,22 @@
 package org.example.age.avs.service.verification.internal;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dagger.Binds;
 import dagger.Module;
+import java.security.PrivateKey;
+import org.example.age.api.JsonSerializer;
 import org.example.age.common.service.crypto.internal.AgeCertificateSignerModule;
 import org.example.age.common.service.crypto.internal.AuthMatchDataEncryptorModule;
-import org.example.age.common.service.key.test.TestKeyModule;
-import org.example.age.site.service.data.internal.SiteServiceJsonSerializerModule;
 
 /**
  * Dagger module that publishes a binding for {@link FakeAvsVerificationFactory}.
  *
- * <p>Also publishes a binding for <code>@Named("service") {@link ObjectMapper}</code>.</p>
+ * <p>Depends on an unbound...</p>
+ * <ul>
+ *     <li><code>@Named("signing") Provider&lt;{@link PrivateKey}&gt;</code></li>
+ *     <li><code>@Named("service") {@link JsonSerializer}</code></li>
+ * </ul>
  */
-@Module(
-        includes = {
-            AgeCertificateSignerModule.class,
-            AuthMatchDataEncryptorModule.class,
-            TestKeyModule.class,
-            SiteServiceJsonSerializerModule.class,
-        })
+@Module(includes = {AgeCertificateSignerModule.class, AuthMatchDataEncryptorModule.class})
 public interface FakeAvsVerificationFactoryModule {
 
     @Binds

--- a/core/site/service/src/testFixtures/java/org/example/age/avs/service/verification/internal/test/TestAvsVerificationFactoryModule.java
+++ b/core/site/service/src/testFixtures/java/org/example/age/avs/service/verification/internal/test/TestAvsVerificationFactoryModule.java
@@ -1,0 +1,11 @@
+package org.example.age.avs.service.verification.internal.test;
+
+import dagger.Module;
+import org.example.age.avs.service.data.internal.AvsServiceJsonSerializerModule;
+import org.example.age.avs.service.verification.internal.FakeAvsVerificationFactory;
+import org.example.age.avs.service.verification.internal.FakeAvsVerificationFactoryModule;
+import org.example.age.common.service.key.test.TestKeyModule;
+
+/** Dagger module that binds dependencies for {@link FakeAvsVerificationFactory}. */
+@Module(includes = {FakeAvsVerificationFactoryModule.class, TestKeyModule.class, AvsServiceJsonSerializerModule.class})
+public interface TestAvsVerificationFactoryModule {}

--- a/core/site/service/src/testFixtures/java/org/example/age/site/service/endpoint/test/TestSiteServiceModule.java
+++ b/core/site/service/src/testFixtures/java/org/example/age/site/service/endpoint/test/TestSiteServiceModule.java
@@ -1,0 +1,29 @@
+package org.example.age.site.service.endpoint.test;
+
+import dagger.Module;
+import io.undertow.server.HttpHandler;
+import org.example.age.common.api.extractor.builtin.DisabledAuthMatchDataExtractorModule;
+import org.example.age.common.api.extractor.test.TestAccountIdExtractorModule;
+import org.example.age.common.service.key.test.TestKeyModule;
+import org.example.age.common.service.store.inmemory.InMemoryPendingStoreFactoryModule;
+import org.example.age.site.service.config.test.TestSiteConfigModule;
+import org.example.age.site.service.endpoint.SiteServiceModule;
+import org.example.age.site.service.store.InMemoryVerificationStoreModule;
+import org.example.age.testing.server.TestServer;
+
+/**
+ * Dagger module that binds dependencies for <code>@Named("api") {@link HttpHandler}</code>.
+ *
+ * <p>Depends on an unbound <code>@Named("avs") {@link TestServer}&lt?&gt;</code>.</p>
+ */
+@Module(
+        includes = {
+            SiteServiceModule.class,
+            TestAccountIdExtractorModule.class,
+            DisabledAuthMatchDataExtractorModule.class,
+            InMemoryVerificationStoreModule.class,
+            InMemoryPendingStoreFactoryModule.class,
+            TestKeyModule.class,
+            TestSiteConfigModule.class,
+        })
+public class TestSiteServiceModule {}

--- a/core/site/service/src/testFixtures/java/org/example/age/site/service/verification/internal/test/TestSiteVerificationManagerModule.java
+++ b/core/site/service/src/testFixtures/java/org/example/age/site/service/verification/internal/test/TestSiteVerificationManagerModule.java
@@ -1,0 +1,22 @@
+package org.example.age.site.service.verification.internal.test;
+
+import dagger.Module;
+import org.example.age.common.service.key.test.TestKeyModule;
+import org.example.age.common.service.store.inmemory.InMemoryPendingStoreFactoryModule;
+import org.example.age.site.service.config.test.StubSiteConfigModule;
+import org.example.age.site.service.data.internal.SiteServiceJsonSerializerModule;
+import org.example.age.site.service.store.InMemoryVerificationStoreModule;
+import org.example.age.site.service.verification.internal.SiteVerificationManager;
+import org.example.age.site.service.verification.internal.SiteVerificationManagerModule;
+
+/** Dagger module that binds dependencies for {@link SiteVerificationManager}. */
+@Module(
+        includes = {
+            SiteVerificationManagerModule.class,
+            InMemoryVerificationStoreModule.class,
+            InMemoryPendingStoreFactoryModule.class,
+            TestKeyModule.class,
+            StubSiteConfigModule.class,
+            SiteServiceJsonSerializerModule.class,
+        })
+public interface TestSiteVerificationManagerModule {}


### PR DESCRIPTION
High-level changes:

- Wire/structure the fake AVS as if it's the real thing.
- Add a module in `[avs/site].service.endpoint.test` that binds dependencies for the service types.
- Add a module in `[avs/site].service.verification.internal.test` that binds dependencies for those internal types.

Corollaries:

- `SiteServiceTest` now only uses Dagger components (not Dagger modules).