### PR TITLE
infra service: remove test @Module's, exact deps

### DIFF
--- a/infra/service/build.gradle.kts
+++ b/infra/service/build.gradle.kts
@@ -18,9 +18,14 @@ dependencies {
     // test
     testAnnotationProcessor("com.google.dagger:dagger-compiler")
 
+    testImplementation(project(":api-types"))
     testImplementation(testFixtures(project(":api-types")))
     testImplementation(project(":infra:api"))
     testImplementation(testFixtures(project(":testing")))
+    testImplementation("com.fasterxml.jackson.core:jackson-core")
+    testImplementation("com.fasterxml.jackson.core:jackson-databind")
+    testImplementation("com.google.dagger:dagger")
     testImplementation("com.squareup.okhttp3:mockwebserver")
     testImplementation("io.undertow:undertow-core")
+    testImplementation("javax.inject:javax.inject")
 }


### PR DESCRIPTION
Notes:

- for tests with a `@Component`, include `testImplementation` deps for dependency injection unconditionally
    - don't need to worry if the module referenced was in `main` or `testFixtures`
- create a Dagger component for the type under test
    - will wire up the `HttpHandler` by hand, using said component