### PR TITLE
s/JsonSerializer/JsonObjects/g

### DIFF
--- a/api-types/src/main/java/org/example/age/api/JsonObjects.java
+++ b/api-types/src/main/java/org/example/age/api/JsonObjects.java
@@ -10,7 +10,7 @@ import java.io.IOException;
  *
  * <p>Types should be serializable using the default object mapper, which has no registered modules.</p>
  */
-public final class JsonSerializer {
+public final class JsonObjects {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
@@ -51,5 +51,5 @@ public final class JsonSerializer {
     }
 
     // static class
-    private JsonSerializer() {}
+    private JsonObjects() {}
 }

--- a/api-types/src/test/java/org/example/age/api/JsonObjectsTest.java
+++ b/api-types/src/test/java/org/example/age/api/JsonObjectsTest.java
@@ -7,28 +7,28 @@ import static org.example.age.testing.api.HttpOptionalAssert.assertThat;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.jupiter.api.Test;
 
-public final class JsonSerializerTest {
+public final class JsonObjectsTest {
 
     @Test
     public void serializeThenDeserialize() {
         String value = "test";
-        byte[] rawValue = JsonSerializer.serialize(value);
-        String rtValue = JsonSerializer.deserialize(rawValue, new TypeReference<>() {});
+        byte[] rawValue = JsonObjects.serialize(value);
+        String rtValue = JsonObjects.deserialize(rawValue, new TypeReference<>() {});
         assertThat(rtValue).isEqualTo(value);
     }
 
     @Test
     public void serializeThenTryDeserialize() {
         String value = "test";
-        byte[] rawValue = JsonSerializer.serialize(value);
-        HttpOptional<String> maybeRtValue = JsonSerializer.tryDeserialize(rawValue, new TypeReference<>() {}, 400);
+        byte[] rawValue = JsonObjects.serialize(value);
+        HttpOptional<String> maybeRtValue = JsonObjects.tryDeserialize(rawValue, new TypeReference<>() {}, 400);
         assertThat(maybeRtValue).hasValue(value);
     }
 
     @Test
     public void serializeFailed() {
-        Object unserializableValue = new JsonSerializerTest();
-        assertThatThrownBy(() -> JsonSerializer.serialize(unserializableValue))
+        Object unserializableValue = new JsonObjectsTest();
+        assertThatThrownBy(() -> JsonObjects.serialize(unserializableValue))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("serialization failed");
     }
@@ -36,7 +36,7 @@ public final class JsonSerializerTest {
     @Test
     public void deserializeFailed() {
         byte[] malformedRawValue = new byte[4];
-        assertThatThrownBy(() -> JsonSerializer.deserialize(malformedRawValue, new TypeReference<>() {}))
+        assertThatThrownBy(() -> JsonObjects.deserialize(malformedRawValue, new TypeReference<>() {}))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("deserialization failed");
     }
@@ -44,8 +44,7 @@ public final class JsonSerializerTest {
     @Test
     public void tryDeserializeFailed() {
         byte[] malformedRawValue = new byte[4];
-        HttpOptional<String> maybeValue =
-                JsonSerializer.tryDeserialize(malformedRawValue, new TypeReference<>() {}, 400);
+        HttpOptional<String> maybeValue = JsonObjects.tryDeserialize(malformedRawValue, new TypeReference<>() {}, 400);
         assertThat(maybeValue).isEmptyWithErrorCode(400);
     }
 }

--- a/core/avs/service-types/src/test/java/org/example/age/avs/service/config/AvsConfigTest.java
+++ b/core/avs/service-types/src/test/java/org/example/age/avs/service/config/AvsConfigTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.time.Duration;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.junit.jupiter.api.Test;
 
 public final class AvsConfigTest {
@@ -14,8 +14,8 @@ public final class AvsConfigTest {
         AvsConfig avsConfig = AvsConfig.builder()
                 .verificationSessionExpiresIn(Duration.ofMinutes(5).toSeconds())
                 .build();
-        byte[] rawAvsConfig = JsonSerializer.serialize(avsConfig);
-        AvsConfig rtAvsConfig = JsonSerializer.deserialize(rawAvsConfig, new TypeReference<>() {});
+        byte[] rawAvsConfig = JsonObjects.serialize(avsConfig);
+        AvsConfig rtAvsConfig = JsonObjects.deserialize(rawAvsConfig, new TypeReference<>() {});
         assertThat(rtAvsConfig).isEqualTo(avsConfig);
     }
 }

--- a/core/avs/service-types/src/test/java/org/example/age/avs/service/config/RegisteredSiteConfigTest.java
+++ b/core/avs/service-types/src/test/java/org/example/age/avs/service/config/RegisteredSiteConfigTest.java
@@ -3,7 +3,7 @@ package org.example.age.avs.service.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.example.age.common.service.config.SiteLocation;
 import org.example.age.data.user.AgeThresholds;
 import org.junit.jupiter.api.Test;
@@ -18,9 +18,9 @@ public final class RegisteredSiteConfigTest {
                 .location(location)
                 .ageThresholds(AgeThresholds.of(13, 18))
                 .build();
-        byte[] rawRegisteredSiteConfig = JsonSerializer.serialize(registeredSiteConfig);
+        byte[] rawRegisteredSiteConfig = JsonObjects.serialize(registeredSiteConfig);
         RegisteredSiteConfig rtRegisteredSiteConfig =
-                JsonSerializer.deserialize(rawRegisteredSiteConfig, new TypeReference<>() {});
+                JsonObjects.deserialize(rawRegisteredSiteConfig, new TypeReference<>() {});
         assertThat(rtRegisteredSiteConfig).isEqualTo(registeredSiteConfig);
     }
 }

--- a/core/common/api-types/src/test/java/org/example/age/common/api/data/VerificationStateTest.java
+++ b/core/common/api-types/src/test/java/org/example/age/common/api/data/VerificationStateTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.time.Duration;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.example.age.data.crypto.SecureId;
 import org.example.age.data.user.VerifiedUser;
 import org.junit.jupiter.api.BeforeAll;
@@ -103,8 +103,8 @@ public final class VerificationStateTest {
     }
 
     private void serializeThenDeserialize(VerificationState state) {
-        byte[] rawState = JsonSerializer.serialize(state);
-        VerificationState rtState = JsonSerializer.deserialize(rawState, new TypeReference<>() {});
+        byte[] rawState = JsonObjects.serialize(state);
+        VerificationState rtState = JsonObjects.deserialize(rawState, new TypeReference<>() {});
         assertThat(rtState).isEqualTo(state);
     }
 }

--- a/core/common/service-types/src/test/java/org/example/age/common/service/config/AvsLocationTest.java
+++ b/core/common/service-types/src/test/java/org/example/age/common/service/config/AvsLocationTest.java
@@ -3,7 +3,7 @@ package org.example.age.common.service.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.example.age.data.crypto.SecureId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,8 +28,8 @@ public final class AvsLocationTest {
 
     @Test
     public void serializeThenDeserialize() {
-        byte[] rawLocation = JsonSerializer.serialize(location);
-        AvsLocation rtLocation = JsonSerializer.deserialize(rawLocation, new TypeReference<>() {});
+        byte[] rawLocation = JsonObjects.serialize(location);
+        AvsLocation rtLocation = JsonObjects.deserialize(rawLocation, new TypeReference<>() {});
         assertThat(rtLocation).isEqualTo(location);
     }
 }

--- a/core/common/service-types/src/test/java/org/example/age/common/service/config/SiteLocationTest.java
+++ b/core/common/service-types/src/test/java/org/example/age/common/service/config/SiteLocationTest.java
@@ -3,7 +3,7 @@ package org.example.age.common.service.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,8 +24,8 @@ public final class SiteLocationTest {
 
     @Test
     public void serializeThenDeserialize() {
-        byte[] rawLocation = JsonSerializer.serialize(location);
-        SiteLocation rtLocation = JsonSerializer.deserialize(rawLocation, new TypeReference<>() {});
+        byte[] rawLocation = JsonObjects.serialize(location);
+        SiteLocation rtLocation = JsonObjects.deserialize(rawLocation, new TypeReference<>() {});
         assertThat(rtLocation).isEqualTo(location);
     }
 }

--- a/core/common/service/src/main/java/org/example/age/common/service/crypto/internal/AuthMatchDataEncryptorImpl.java
+++ b/core/common/service/src/main/java/org/example/age/common/service/crypto/internal/AuthMatchDataEncryptorImpl.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.example.age.api.HttpOptional;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.example.age.common.api.data.AuthMatchData;
 import org.example.age.data.crypto.Aes256Key;
 import org.example.age.data.crypto.AesGcmEncryptionPackage;
@@ -18,7 +18,7 @@ final class AuthMatchDataEncryptorImpl implements AuthMatchDataEncryptor {
 
     @Override
     public AesGcmEncryptionPackage encrypt(AuthMatchData authData, Aes256Key authKey) {
-        byte[] rawAuthData = JsonSerializer.serialize(authData);
+        byte[] rawAuthData = JsonObjects.serialize(authData);
         return AesGcmEncryptionPackage.encrypt(rawAuthData, authKey);
     }
 
@@ -30,6 +30,6 @@ final class AuthMatchDataEncryptorImpl implements AuthMatchDataEncryptor {
         }
         byte[] rawAuthData = maybeRawAuthData.get();
 
-        return JsonSerializer.tryDeserialize(rawAuthData, new TypeReference<>() {}, 400);
+        return JsonObjects.tryDeserialize(rawAuthData, new TypeReference<>() {}, 400);
     }
 }

--- a/core/data/src/main/java/org/example/age/data/certificate/SignedAgeCertificate.java
+++ b/core/data/src/main/java/org/example/age/data/certificate/SignedAgeCertificate.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import org.example.age.api.ApiStyle;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.example.age.data.crypto.DigitalSignature;
 import org.immutables.value.Value;
 
@@ -28,7 +28,7 @@ public interface SignedAgeCertificate {
 
     /** Signs the age certificate. */
     static SignedAgeCertificate sign(AgeCertificate certificate, PrivateKey privateKey) {
-        byte[] rawCertificate = JsonSerializer.serialize(certificate);
+        byte[] rawCertificate = JsonObjects.serialize(certificate);
         DigitalSignature signature = DigitalSignature.sign(rawCertificate, privateKey);
         return of(certificate, signature);
     }
@@ -41,7 +41,7 @@ public interface SignedAgeCertificate {
 
     /** Verifies the signature against the age certificate, returning whether verification succeeded. */
     default boolean verify(PublicKey publicKey) {
-        byte[] rawCertificate = JsonSerializer.serialize(ageCertificate());
+        byte[] rawCertificate = JsonObjects.serialize(ageCertificate());
         return signature().verify(rawCertificate, publicKey);
     }
 }

--- a/core/data/src/test/java/org/example/age/data/certificate/AgeCertificateTest.java
+++ b/core/data/src/test/java/org/example/age/data/certificate/AgeCertificateTest.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Optional;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.example.age.data.crypto.Aes256Key;
 import org.example.age.data.crypto.AesGcmEncryptionPackage;
 import org.example.age.data.crypto.SecureId;
@@ -35,8 +35,8 @@ public final class AgeCertificateTest {
     @Test
     public void serializeThenDeserialize() {
         AgeCertificate certificate = createAgeCertificate();
-        byte[] rawCertificate = JsonSerializer.serialize(certificate);
-        AgeCertificate rtCertificate = JsonSerializer.deserialize(rawCertificate, new TypeReference<>() {});
+        byte[] rawCertificate = JsonObjects.serialize(certificate);
+        AgeCertificate rtCertificate = JsonObjects.deserialize(rawCertificate, new TypeReference<>() {});
         assertThat(rtCertificate).isEqualTo(certificate);
     }
 

--- a/core/data/src/test/java/org/example/age/data/certificate/SignedAgeCertificateTest.java
+++ b/core/data/src/test/java/org/example/age/data/certificate/SignedAgeCertificateTest.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.time.Duration;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.example.age.data.crypto.Aes256Key;
 import org.example.age.data.crypto.AesGcmEncryptionPackage;
 import org.example.age.data.crypto.DigitalSignature;
@@ -46,9 +46,9 @@ public final class SignedAgeCertificateTest {
     public void serializeThenDeserialize() {
         AgeCertificate certificate = createAgeCertificate();
         SignedAgeCertificate signedCertificate = SignedAgeCertificate.sign(certificate, keyPair.getPrivate());
-        byte[] rawSignedCertificate = JsonSerializer.serialize(signedCertificate);
+        byte[] rawSignedCertificate = JsonObjects.serialize(signedCertificate);
         SignedAgeCertificate rtSignedCertificate =
-                JsonSerializer.deserialize(rawSignedCertificate, new TypeReference<>() {});
+                JsonObjects.deserialize(rawSignedCertificate, new TypeReference<>() {});
         assertThat(rtSignedCertificate).isEqualTo(signedCertificate);
     }
 
@@ -56,9 +56,9 @@ public final class SignedAgeCertificateTest {
     public void signThenSerializeThenDeserializeThenVerify() {
         AgeCertificate certificate = createAgeCertificate();
         SignedAgeCertificate signedCertificate = SignedAgeCertificate.sign(certificate, keyPair.getPrivate());
-        byte[] rawSignedCertificate = JsonSerializer.serialize(signedCertificate);
+        byte[] rawSignedCertificate = JsonObjects.serialize(signedCertificate);
         SignedAgeCertificate rtSignedCertificate =
-                JsonSerializer.deserialize(rawSignedCertificate, new TypeReference<>() {});
+                JsonObjects.deserialize(rawSignedCertificate, new TypeReference<>() {});
         boolean wasVerified = rtSignedCertificate.verify(keyPair.getPublic());
         assertThat(wasVerified).isTrue();
     }

--- a/core/data/src/test/java/org/example/age/data/certificate/VerificationRequestTest.java
+++ b/core/data/src/test/java/org/example/age/data/certificate/VerificationRequestTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.time.Duration;
 import org.assertj.core.data.Offset;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.junit.jupiter.api.Test;
 
 public final class VerificationRequestTest {
@@ -50,8 +50,8 @@ public final class VerificationRequestTest {
     @Test
     public void serializeThenDeserialize() {
         VerificationRequest request = VerificationRequest.generateForSite(SITE_ID, EXPIRES_IN);
-        byte[] rawRequest = JsonSerializer.serialize(request);
-        VerificationRequest rtRequest = JsonSerializer.deserialize(rawRequest, new TypeReference<>() {});
+        byte[] rawRequest = JsonObjects.serialize(request);
+        VerificationRequest rtRequest = JsonObjects.deserialize(rawRequest, new TypeReference<>() {});
         assertThat(rtRequest).isEqualTo(request);
     }
 }

--- a/core/data/src/test/java/org/example/age/data/certificate/VerificationSessionTest.java
+++ b/core/data/src/test/java/org/example/age/data/certificate/VerificationSessionTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.time.Duration;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.junit.jupiter.api.Test;
 
 public final class VerificationSessionTest {
@@ -13,8 +13,8 @@ public final class VerificationSessionTest {
     public void serializeThenDeserialize() {
         VerificationRequest request = VerificationRequest.generateForSite("Site", Duration.ofMinutes(5));
         VerificationSession session = VerificationSession.create(request);
-        byte[] rawSession = JsonSerializer.serialize(session);
-        VerificationSession rtSession = JsonSerializer.deserialize(rawSession, new TypeReference<>() {});
+        byte[] rawSession = JsonObjects.serialize(session);
+        VerificationSession rtSession = JsonObjects.deserialize(rawSession, new TypeReference<>() {});
         assertThat(rtSession).isEqualTo(session);
     }
 }

--- a/core/data/src/test/java/org/example/age/data/crypto/Aes256KeyTest.java
+++ b/core/data/src/test/java/org/example/age/data/crypto/Aes256KeyTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.junit.jupiter.api.Test;
 
 public final class Aes256KeyTest {
@@ -19,8 +19,8 @@ public final class Aes256KeyTest {
     @Test
     public void serializeThenDeserialize() {
         Aes256Key key = Aes256Key.generate();
-        byte[] rawKey = JsonSerializer.serialize(key);
-        Aes256Key rtKey = JsonSerializer.deserialize(rawKey, new TypeReference<>() {});
+        byte[] rawKey = JsonObjects.serialize(key);
+        Aes256Key rtKey = JsonObjects.deserialize(rawKey, new TypeReference<>() {});
         assertThat(rtKey).isEqualTo(key);
     }
 

--- a/core/data/src/test/java/org/example/age/data/crypto/AesGcmEncryptionPackageTest.java
+++ b/core/data/src/test/java/org/example/age/data/crypto/AesGcmEncryptionPackageTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -40,18 +40,18 @@ public final class AesGcmEncryptionPackageTest {
     @Test
     public void serializeThenDeserialize() {
         AesGcmEncryptionPackage encryptionPackage = AesGcmEncryptionPackage.encrypt(PLAINTEXT, key);
-        byte[] rawEncryptionPackage = JsonSerializer.serialize(encryptionPackage);
+        byte[] rawEncryptionPackage = JsonObjects.serialize(encryptionPackage);
         AesGcmEncryptionPackage rtEncryptionPackage =
-                JsonSerializer.deserialize(rawEncryptionPackage, new TypeReference<>() {});
+                JsonObjects.deserialize(rawEncryptionPackage, new TypeReference<>() {});
         assertThat(rtEncryptionPackage).isEqualTo(encryptionPackage);
     }
 
     @Test
     public void encryptThenSerializeThenDeserializeThenDecrypt() {
         AesGcmEncryptionPackage encryptionPackage = AesGcmEncryptionPackage.encrypt(PLAINTEXT, key);
-        byte[] rawEncryptionPackage = JsonSerializer.serialize(encryptionPackage);
+        byte[] rawEncryptionPackage = JsonObjects.serialize(encryptionPackage);
         AesGcmEncryptionPackage rtEncryptionPackage =
-                JsonSerializer.deserialize(rawEncryptionPackage, new TypeReference<>() {});
+                JsonObjects.deserialize(rawEncryptionPackage, new TypeReference<>() {});
         Optional<byte[]> maybeRtPlaintext = rtEncryptionPackage.tryDecrypt(key);
         assertThat(maybeRtPlaintext).hasValue(PLAINTEXT);
     }

--- a/core/data/src/test/java/org/example/age/data/crypto/BytesValueTest.java
+++ b/core/data/src/test/java/org/example/age/data/crypto/BytesValueTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.nio.charset.StandardCharsets;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.junit.jupiter.api.Test;
 
 public class BytesValueTest {
@@ -20,8 +20,8 @@ public class BytesValueTest {
     @Test
     public void serializeThenDeserialize() {
         BytesValue value = BytesValue.ofBytes(BYTES);
-        byte[] rawValue = JsonSerializer.serialize(value);
-        BytesValue rtValue = JsonSerializer.deserialize(rawValue, new TypeReference<>() {});
+        byte[] rawValue = JsonObjects.serialize(value);
+        BytesValue rtValue = JsonObjects.deserialize(rawValue, new TypeReference<>() {});
         assertThat(rtValue).isEqualTo(value);
     }
 }

--- a/core/data/src/test/java/org/example/age/data/crypto/DigitalSignatureTest.java
+++ b/core/data/src/test/java/org/example/age/data/crypto/DigitalSignatureTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -38,16 +38,16 @@ public final class DigitalSignatureTest {
     @Test
     public void serializeThenDeserialize() {
         DigitalSignature signature = DigitalSignature.sign(MESSAGE, keyPair.getPrivate());
-        byte[] rawSignature = JsonSerializer.serialize(signature);
-        DigitalSignature rtSignature = JsonSerializer.deserialize(rawSignature, new TypeReference<>() {});
+        byte[] rawSignature = JsonObjects.serialize(signature);
+        DigitalSignature rtSignature = JsonObjects.deserialize(rawSignature, new TypeReference<>() {});
         assertThat(rtSignature).isEqualTo(signature);
     }
 
     @Test
     public void signThenSerializeThenDeserializeThenVerify() {
         DigitalSignature signature = DigitalSignature.sign(MESSAGE, keyPair.getPrivate());
-        byte[] rawSignature = JsonSerializer.serialize(signature);
-        DigitalSignature rtSignature = JsonSerializer.deserialize(rawSignature, new TypeReference<>() {});
+        byte[] rawSignature = JsonObjects.serialize(signature);
+        DigitalSignature rtSignature = JsonObjects.deserialize(rawSignature, new TypeReference<>() {});
         boolean wasVerified = rtSignature.verify(MESSAGE, keyPair.getPublic());
         assertThat(wasVerified).isTrue();
     }

--- a/core/data/src/test/java/org/example/age/data/crypto/SecureIdTest.java
+++ b/core/data/src/test/java/org/example/age/data/crypto/SecureIdTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.junit.jupiter.api.Test;
 
 public final class SecureIdTest {
@@ -27,8 +27,8 @@ public final class SecureIdTest {
     @Test
     public void serializeThenDeserialize() {
         SecureId id = SecureId.generate();
-        byte[] rawId = JsonSerializer.serialize(id);
-        SecureId rtId = JsonSerializer.deserialize(rawId, new TypeReference<>() {});
+        byte[] rawId = JsonObjects.serialize(id);
+        SecureId rtId = JsonObjects.deserialize(rawId, new TypeReference<>() {});
         assertThat(rtId).isEqualTo(id);
     }
 

--- a/core/data/src/test/java/org/example/age/data/crypto/internal/SecureRandomImmutableBytesTest.java
+++ b/core/data/src/test/java/org/example/age/data/crypto/internal/SecureRandomImmutableBytesTest.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import org.assertj.core.api.ThrowableAssert;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.example.age.data.internal.StaticFromStringDeserializer;
 import org.junit.jupiter.api.Test;
 
@@ -24,8 +24,8 @@ public final class SecureRandomImmutableBytesTest {
     @Test
     public void serializeThenDeserialize() {
         TestObject o = TestObject.generate();
-        byte[] rawO = JsonSerializer.serialize(o);
-        TestObject rtO = JsonSerializer.deserialize(rawO, new TypeReference<>() {});
+        byte[] rawO = JsonObjects.serialize(o);
+        TestObject rtO = JsonObjects.deserialize(rawO, new TypeReference<>() {});
         assertThat(rtO).isEqualTo(o);
     }
 

--- a/core/data/src/test/java/org/example/age/data/internal/ImmutableBytesTest.java
+++ b/core/data/src/test/java/org/example/age/data/internal/ImmutableBytesTest.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import com.google.common.testing.EqualsTester;
 import java.util.Arrays;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.junit.jupiter.api.Test;
 
 public final class ImmutableBytesTest {
@@ -32,8 +32,8 @@ public final class ImmutableBytesTest {
     @Test
     public void serializeThenDeserialize() {
         TestObject o = TestObject.ofBytes(RAW_O_BYTES);
-        byte[] rawO = JsonSerializer.serialize(o);
-        TestObject rtO = JsonSerializer.deserialize(rawO, new TypeReference<>() {});
+        byte[] rawO = JsonObjects.serialize(o);
+        TestObject rtO = JsonObjects.deserialize(rawO, new TypeReference<>() {});
         assertThat(rtO).isEqualTo(o);
     }
 

--- a/core/data/src/test/java/org/example/age/data/internal/StaticFromStringDeserializerTest.java
+++ b/core/data/src/test/java/org/example/age/data/internal/StaticFromStringDeserializerTest.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.junit.jupiter.api.Test;
 
 public final class StaticFromStringDeserializerTest {
@@ -14,8 +14,8 @@ public final class StaticFromStringDeserializerTest {
     @Test
     public void serializeThenDeserialize() {
         TestObject o = TestObject.fromString("test");
-        byte[] rawO = JsonSerializer.serialize(o);
-        TestObject rtO = JsonSerializer.deserialize(rawO, new TypeReference<>() {});
+        byte[] rawO = JsonObjects.serialize(o);
+        TestObject rtO = JsonObjects.deserialize(rawO, new TypeReference<>() {});
         assertThat(rtO.toString()).isEqualTo(o.toString());
     }
 

--- a/core/data/src/test/java/org/example/age/data/user/AgeRangeTest.java
+++ b/core/data/src/test/java/org/example/age/data/user/AgeRangeTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.testing.EqualsTester;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.junit.jupiter.api.Test;
 
 public final class AgeRangeTest {
@@ -113,8 +113,8 @@ public final class AgeRangeTest {
     }
 
     private void serializeThenDeserialize(AgeRange ageRange) {
-        byte[] rawAgeRange = JsonSerializer.serialize(ageRange);
-        AgeRange rtAgeRange = JsonSerializer.deserialize(rawAgeRange, new TypeReference<>() {});
+        byte[] rawAgeRange = JsonObjects.serialize(ageRange);
+        AgeRange rtAgeRange = JsonObjects.deserialize(rawAgeRange, new TypeReference<>() {});
         assertThat(rtAgeRange).isEqualTo(ageRange);
     }
 

--- a/core/data/src/test/java/org/example/age/data/user/AgeThresholdsTest.java
+++ b/core/data/src/test/java/org/example/age/data/user/AgeThresholdsTest.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.testing.EqualsTester;
 import java.util.ArrayList;
 import java.util.List;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.junit.jupiter.api.Test;
 
 public final class AgeThresholdsTest {
@@ -68,8 +68,8 @@ public final class AgeThresholdsTest {
     @Test
     public void serializeThenDeserialize() {
         AgeThresholds ageThresholds = AgeThresholds.of(13, 18);
-        byte[] rawAgeThresholds = JsonSerializer.serialize(ageThresholds);
-        AgeThresholds rtAgeThresholds = JsonSerializer.deserialize(rawAgeThresholds, new TypeReference<>() {});
+        byte[] rawAgeThresholds = JsonObjects.serialize(ageThresholds);
+        AgeThresholds rtAgeThresholds = JsonObjects.deserialize(rawAgeThresholds, new TypeReference<>() {});
         assertThat(rtAgeThresholds).isEqualTo(ageThresholds);
     }
 

--- a/core/data/src/test/java/org/example/age/data/user/VerifiedUserTest.java
+++ b/core/data/src/test/java/org/example/age/data/user/VerifiedUserTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.example.age.data.crypto.SecureId;
 import org.junit.jupiter.api.Test;
 
@@ -39,8 +39,8 @@ public final class VerifiedUserTest {
     @Test
     public void serializeThenDeserialize() {
         VerifiedUser user = VerifiedUser.of(SecureId.generate(), 18);
-        byte[] rawUser = JsonSerializer.serialize(user);
-        VerifiedUser rtUser = JsonSerializer.deserialize(rawUser, new TypeReference<>() {});
+        byte[] rawUser = JsonObjects.serialize(user);
+        VerifiedUser rtUser = JsonObjects.deserialize(rawUser, new TypeReference<>() {});
         assertThat(rtUser).isEqualTo(user);
     }
 }

--- a/core/site/service-types/src/test/java/org/example/age/site/service/config/SiteConfigTest.java
+++ b/core/site/service-types/src/test/java/org/example/age/site/service/config/SiteConfigTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.time.Duration;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.example.age.common.service.config.AvsLocation;
 import org.junit.jupiter.api.Test;
 
@@ -19,8 +19,8 @@ public final class SiteConfigTest {
                 .id("Site")
                 .verifiedAccountExpiresInMinutes(Duration.ofDays(30).toMinutes())
                 .build();
-        byte[] rawSiteConfig = JsonSerializer.serialize(siteConfig);
-        SiteConfig rtSiteConfig = JsonSerializer.deserialize(rawSiteConfig, new TypeReference<>() {});
+        byte[] rawSiteConfig = JsonObjects.serialize(siteConfig);
+        SiteConfig rtSiteConfig = JsonObjects.deserialize(rawSiteConfig, new TypeReference<>() {});
         assertThat(rtSiteConfig).isEqualTo(siteConfig);
     }
 }

--- a/infra/api/src/main/java/org/example/age/infra/api/ExchangeJsonSender.java
+++ b/infra/api/src/main/java/org/example/age/infra/api/ExchangeJsonSender.java
@@ -5,8 +5,8 @@ import io.undertow.util.Headers;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.example.age.api.HttpOptional;
+import org.example.age.api.JsonObjects;
 import org.example.age.api.JsonSender;
-import org.example.age.api.JsonSerializer;
 
 /** {@link JsonSender} that is backed by an {@link HttpServerExchange}. */
 public final class ExchangeJsonSender<V> implements JsonSender<V> {
@@ -36,7 +36,7 @@ public final class ExchangeJsonSender<V> implements JsonSender<V> {
 
     /** Sends a JSON body. */
     private void sendValueInternal(Object value) {
-        byte[] rawValue = JsonSerializer.serialize(value);
+        byte[] rawValue = JsonObjects.serialize(value);
         exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
         exchange.getResponseSender().send(ByteBuffer.wrap(rawValue));
     }

--- a/infra/api/src/main/java/org/example/age/infra/api/RequestParser.java
+++ b/infra/api/src/main/java/org/example/age/infra/api/RequestParser.java
@@ -7,7 +7,7 @@ import io.undertow.util.StatusCodes;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import org.example.age.api.HttpOptional;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.xnio.IoUtils;
 
 /** Parses API arguments from an HTTP request. */
@@ -45,8 +45,8 @@ public final class RequestParser {
         }
 
         String rawValue = maybeRawValue.get();
-        byte[] json = JsonSerializer.serialize(rawValue);
-        return JsonSerializer.tryDeserialize(json, valueTypeRef, StatusCodes.BAD_REQUEST);
+        byte[] json = JsonObjects.serialize(rawValue);
+        return JsonObjects.tryDeserialize(json, valueTypeRef, StatusCodes.BAD_REQUEST);
     }
 
     /**
@@ -80,7 +80,7 @@ public final class RequestParser {
 
         @Override
         public void handle(HttpServerExchange exchange, byte[] rawValue) {
-            HttpOptional<V> maybeValue = JsonSerializer.tryDeserialize(rawValue, valueTypeRef, StatusCodes.BAD_REQUEST);
+            HttpOptional<V> maybeValue = JsonObjects.tryDeserialize(rawValue, valueTypeRef, StatusCodes.BAD_REQUEST);
             if (maybeValue.isEmpty()) {
                 sendErrorCode(maybeValue.statusCode());
                 return;

--- a/infra/client/src/main/java/org/example/age/infra/client/JsonApiRequest.java
+++ b/infra/client/src/main/java/org/example/age/infra/client/JsonApiRequest.java
@@ -8,7 +8,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 
 /**
  * HTTP request for a JSON API.
@@ -68,7 +68,7 @@ public final class JsonApiRequest {
 
         /** Sets the JSON body. */
         public Builder body(Object requestValue) {
-            byte[] rawRequestValue = JsonSerializer.serialize(requestValue);
+            byte[] rawRequestValue = JsonObjects.serialize(requestValue);
             body = RequestBody.create(rawRequestValue, JSON_CONTENT_TYPE);
             return this;
         }

--- a/infra/service/src/main/java/org/example/age/infra/service/client/RequestDispatcherImpl.java
+++ b/infra/service/src/main/java/org/example/age/infra/service/client/RequestDispatcherImpl.java
@@ -9,7 +9,7 @@ import okhttp3.Callback;
 import okhttp3.Response;
 import org.example.age.api.Dispatcher;
 import org.example.age.api.HttpOptional;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.example.age.api.Sender;
 import org.example.age.infra.client.JsonApiRequest;
 import org.example.age.infra.service.client.internal.ExchangeClient;
@@ -154,7 +154,7 @@ final class RequestDispatcherImpl implements RequestDispatcher {
             byte[] rawResponseValue = maybeRawResponseValue.get();
 
             HttpOptional<V> maybeResponseValue =
-                    JsonSerializer.tryDeserialize(rawResponseValue, responseValueTypeRef, 502);
+                    JsonObjects.tryDeserialize(rawResponseValue, responseValueTypeRef, 502);
             if (maybeResponseValue.isEmpty()) {
                 sender.sendErrorCode(maybeResponseValue.statusCode());
                 return;

--- a/infra/service/src/main/java/org/example/age/infra/service/client/RequestDispatcherModule.java
+++ b/infra/service/src/main/java/org/example/age/infra/service/client/RequestDispatcherModule.java
@@ -2,13 +2,13 @@ package org.example.age.infra.service.client;
 
 import dagger.Binds;
 import dagger.Module;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.example.age.infra.service.client.internal.ExchangeClientModule;
 
 /**
  * Dagger module that publishes a binding for {@link RequestDispatcher}.
  *
- * <p>Depends on an unbound <code>@Named("service") {@link JsonSerializer}</code>.</p>
+ * <p>Depends on an unbound <code>@Named("service") {@link JsonObjects}</code>.</p>
  */
 @Module(includes = ExchangeClientModule.class)
 public interface RequestDispatcherModule {

--- a/infra/service/src/test/java/org/example/age/infra/service/client/internal/ExchangeClientTest.java
+++ b/infra/service/src/test/java/org/example/age/infra/service/client/internal/ExchangeClientTest.java
@@ -16,8 +16,8 @@ import okhttp3.Response;
 import okhttp3.mockwebserver.MockResponse;
 import org.example.age.api.Dispatcher;
 import org.example.age.api.HttpOptional;
+import org.example.age.api.JsonObjects;
 import org.example.age.api.JsonSender;
-import org.example.age.api.JsonSerializer;
 import org.example.age.infra.api.ExchangeDispatcher;
 import org.example.age.infra.api.ExchangeJsonSender;
 import org.example.age.testing.client.TestClient;
@@ -83,7 +83,7 @@ public final class ExchangeClientTest {
             }
 
             private static void onRecipientReceived(JsonSender<String> sender, Response response) throws IOException {
-                HttpOptional<String> maybeRecipient = JsonSerializer.tryDeserialize(
+                HttpOptional<String> maybeRecipient = JsonObjects.tryDeserialize(
                         response.body().bytes(), new TypeReference<>() {}, StatusCodes.BAD_GATEWAY);
                 if (maybeRecipient.isEmpty()) {
                     sender.sendErrorCode(maybeRecipient.statusCode());

--- a/module/extractor/common/builtin/src/test/java/org/example/age/common/api/extractor/builtin/DisabledAuthMatchDataTest.java
+++ b/module/extractor/common/builtin/src/test/java/org/example/age/common/api/extractor/builtin/DisabledAuthMatchDataTest.java
@@ -3,7 +3,7 @@ package org.example.age.common.api.extractor.builtin;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.example.age.common.api.data.AuthMatchData;
 import org.junit.jupiter.api.Test;
 
@@ -20,8 +20,8 @@ public final class DisabledAuthMatchDataTest {
     @Test
     public void serializeThenDeserialize() {
         AuthMatchData authData = DisabledAuthMatchData.of();
-        byte[] rawAuthData = JsonSerializer.serialize(authData);
-        AuthMatchData rtAuthData = JsonSerializer.deserialize(rawAuthData, new TypeReference<>() {});
+        byte[] rawAuthData = JsonObjects.serialize(authData);
+        AuthMatchData rtAuthData = JsonObjects.deserialize(rawAuthData, new TypeReference<>() {});
         assertThat(rtAuthData).isEqualTo(authData);
     }
 }

--- a/module/extractor/common/builtin/src/test/java/org/example/age/common/api/extractor/builtin/UserAgentAuthMatchDataTest.java
+++ b/module/extractor/common/builtin/src/test/java/org/example/age/common/api/extractor/builtin/UserAgentAuthMatchDataTest.java
@@ -3,7 +3,7 @@ package org.example.age.common.api.extractor.builtin;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.example.age.common.api.data.AuthMatchData;
 import org.junit.jupiter.api.Test;
 
@@ -28,8 +28,8 @@ public final class UserAgentAuthMatchDataTest {
     @Test
     public void serializeThenDeserialize() {
         AuthMatchData authData = UserAgentAuthMatchData.of("agent");
-        byte[] rawAuthData = JsonSerializer.serialize(authData);
-        AuthMatchData rtAuthData = JsonSerializer.deserialize(rawAuthData, new TypeReference<>() {});
+        byte[] rawAuthData = JsonObjects.serialize(authData);
+        AuthMatchData rtAuthData = JsonObjects.deserialize(rawAuthData, new TypeReference<>() {});
         assertThat(rtAuthData).isEqualTo(authData);
     }
 }

--- a/module/store/common/inmemory/src/main/java/org/example/age/common/service/store/inmemory/InMemoryPendingStore.java
+++ b/module/store/common/inmemory/src/main/java/org/example/age/common/service/store/inmemory/InMemoryPendingStore.java
@@ -7,7 +7,7 @@ import com.google.common.collect.Maps;
 import java.lang.reflect.Type;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.example.age.common.service.store.PendingStore;
 import org.xnio.XnioExecutor;
 
@@ -39,7 +39,7 @@ final class InMemoryPendingStore<V> implements PendingStore<V> {
             return;
         }
 
-        byte[] rawValue = JsonSerializer.serialize(value);
+        byte[] rawValue = JsonObjects.serialize(value);
         ExpirableRawValue expirableRawValue = new ExpirableRawValue(rawValue);
         Optional<ExpirableRawValue> maybeOldExpirableRawValue = Optional.ofNullable(store.put(key, expirableRawValue));
         expirableRawValue.scheduleExpiration(expiresIn, executor);
@@ -54,7 +54,7 @@ final class InMemoryPendingStore<V> implements PendingStore<V> {
         }
         ExpirableRawValue expirableRawValue = maybeExpirableRawValue.get();
 
-        V value = JsonSerializer.deserialize(expirableRawValue.get(), valueTypeRef);
+        V value = JsonObjects.deserialize(expirableRawValue.get(), valueTypeRef);
         return Optional.of(value);
     }
 
@@ -67,7 +67,7 @@ final class InMemoryPendingStore<V> implements PendingStore<V> {
         ExpirableRawValue expirableRawValue = maybeExpirableRawValue.get();
 
         expirableRawValue.cancelExpiration();
-        V value = JsonSerializer.deserialize(expirableRawValue.get(), valueTypeRef);
+        V value = JsonObjects.deserialize(expirableRawValue.get(), valueTypeRef);
         return Optional.of(value);
     }
 

--- a/testing/src/testFixtures/java/org/example/age/testing/client/TestClient.java
+++ b/testing/src/testFixtures/java/org/example/age/testing/client/TestClient.java
@@ -8,7 +8,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.example.age.api.HttpOptional;
-import org.example.age.api.JsonSerializer;
+import org.example.age.api.JsonObjects;
 import org.example.age.infra.client.JsonApiRequest;
 
 /** Shared HTTP client for testing. */
@@ -110,7 +110,7 @@ public final class TestClient {
 
             checkContentType(response, JSON_CONTENT_TYPE);
             byte[] rawResponseValue = response.body().bytes();
-            V responseValue = JsonSerializer.deserialize(rawResponseValue, responseValueTypeRef);
+            V responseValue = JsonObjects.deserialize(rawResponseValue, responseValueTypeRef);
             return HttpOptional.of(responseValue);
         }
 


### PR DESCRIPTION
`JsonSerializer` is also a Jackson type, while `JsonObjects` does not conflict with a Jackson type. (Context: importing or autocompleting a type in an IDE)