### PR TITLE
add API handlers with args

### DIFF
--- a/api/base/src/main/java/org/example/age/api/base/ApiHandler.java
+++ b/api/base/src/main/java/org/example/age/api/base/ApiHandler.java
@@ -1,8 +1,40 @@
 package org.example.age.api.base;
 
-/** API handler that can send a response or dispatch the request. */
-@FunctionalInterface
-public interface ApiHandler<S extends Sender> {
+/** Asynchronous API handler that can send a response or dispatch the request. */
+public interface ApiHandler {
 
-    void handleRequest(S sender, Dispatcher dispatcher) throws Exception;
+    /** API handler for a request with zero arguments. */
+    @FunctionalInterface
+    interface ZeroArg<S extends Sender> {
+
+        void handleRequest(S sender, Dispatcher dispatcher) throws Exception;
+    }
+
+    /** API handler for a request with one argument. */
+    @FunctionalInterface
+    interface OneArg<S extends Sender, A> {
+
+        void handleRequest(S sender, A arg, Dispatcher dispatcher) throws Exception;
+    }
+
+    /** API handler for a request with two arguments. */
+    @FunctionalInterface
+    interface TwoArg<S extends Sender, A1, A2> {
+
+        void handleRequest(S sender, A1 arg1, A2 arg2, Dispatcher dispatcher) throws Exception;
+    }
+
+    /** API handler for a request with three arguments. */
+    @FunctionalInterface
+    interface ThreeArg<S extends Sender, A1, A2, A3> {
+
+        void handleRequest(S sender, A1 arg1, A2 arg2, A3 arg3, Dispatcher dispatcher) throws Exception;
+    }
+
+    /** API handler for a request with four arguments. */
+    @FunctionalInterface
+    interface FourArg<S extends Sender, A1, A2, A3, A4> {
+
+        void handleRequest(S sender, A1 arg1, A2 arg2, A3 arg3, A4 arg4, Dispatcher dispatcher) throws Exception;
+    }
 }

--- a/api/base/src/main/java/org/example/age/api/base/DispatchedHandler.java
+++ b/api/base/src/main/java/org/example/age/api/base/DispatchedHandler.java
@@ -1,0 +1,13 @@
+package org.example.age.api.base;
+
+/**
+ * Handler that runs on the worker thread when a request is manually dispatched
+ * (i.e., when {@link Dispatcher#dispatched()} was called).
+ *
+ * <p>The worker thread should immediately call {@link Dispatcher#executeHandler(DispatchedHandler)}.</p>
+ */
+@FunctionalInterface
+public interface DispatchedHandler {
+
+    void handleRequest() throws Exception;
+}

--- a/api/base/src/main/java/org/example/age/api/base/Dispatcher.java
+++ b/api/base/src/main/java/org/example/age/api/base/Dispatcher.java
@@ -3,12 +3,12 @@ package org.example.age.api.base;
 import java.util.concurrent.ExecutorService;
 
 /**
- * Dispatches requests to the worker thread pool, and also schedules tasks.
+ * Dispatches a request to the worker thread pool, and also schedules tasks.
  *
  * <p>Requests run on an IO thread, so requests that block should be dispatched to a worker thread.</p>
  *
- * <p>By default, the underlying HTTP exchange completes when the request handler returns.
- * Calling {@link #dispatch(Sender, ApiHandler)} (or {@link #dispatched()}) will prevent that from happening.</p>
+ * <p>The behavior is undefined if a response is not sent and the request is not dispatched.
+ * If a response is not sent, the request should be dispatched via {@link #dispatch} (or {@link #dispatched()}).</p>
  */
 public interface Dispatcher {
 
@@ -22,11 +22,25 @@ public interface Dispatcher {
     ExecutorService getWorker();
 
     /** Dispatches this request to the worker thread pool. */
-    <S extends Sender> void dispatch(S sender, ApiHandler<S> handler);
+    <S extends Sender> void dispatch(S sender, ApiHandler.ZeroArg<S> handler);
 
-    /** Called when this request is dispatched without calling {@link #dispatch(Sender, ApiHandler)}. */
+    /** Dispatches this request to the worker thread pool. */
+    <S extends Sender, A> void dispatch(S sender, A arg, ApiHandler.OneArg<S, A> handler);
+
+    /** Dispatches this request to the worker thread pool. */
+    <S extends Sender, A1, A2> void dispatch(S sender, A1 arg, A2 arg2, ApiHandler.TwoArg<S, A1, A2> handler);
+
+    /** Dispatches this request to the worker thread pool. */
+    <S extends Sender, A1, A2, A3> void dispatch(
+            S sender, A1 arg, A2 arg2, A3 arg3, ApiHandler.ThreeArg<S, A1, A2, A3> handler);
+
+    /** Dispatches this request to the worker thread pool. */
+    <S extends Sender, A1, A2, A3, A4> void dispatch(
+            S sender, A1 arg, A2 arg2, A3 arg3, A4 arg4, ApiHandler.FourArg<S, A1, A2, A3, A4> handler);
+
+    /** Called when this request is dispatched without calling {@link #dispatch}. */
     void dispatched();
 
-    /** Executes the handler on the dispatched thread when {@link #dispatch(Sender, ApiHandler)} was not called. */
-    <S extends Sender> void executeHandler(S sender, ApiHandler<S> handler);
+    /** Called on the worker thread to execute the handler. Used when {@link #dispatched()} was called. */
+    <S extends Sender> void executeHandler(DispatchedHandler handler);
 }

--- a/api/base/src/testFixtures/java/org/example/age/testing/api/StubDispatcher.java
+++ b/api/base/src/testFixtures/java/org/example/age/testing/api/StubDispatcher.java
@@ -8,10 +8,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import org.example.age.api.base.ApiHandler;
 import org.example.age.api.base.Dispatcher;
 import org.example.age.api.base.ScheduledExecutor;
-import org.example.age.api.base.Sender;
 
 /**
  * Stub {@link Dispatcher} that no-ops when it dispatches API calls or uses the executors.
@@ -20,41 +18,25 @@ import org.example.age.api.base.Sender;
  *
  * <p>It assumes that the executors only call methods with {@code execute} or {@code submit} in the name.</p>
  */
-public final class StubDispatcher implements Dispatcher {
+public final class StubDispatcher {
 
-    private static final Dispatcher instance = new StubDispatcher();
-
-    private final ScheduledExecutor ioThread = createStubIoThread();
-    private final ExecutorService worker = createStubWorker();
+    private static final Dispatcher instance = create();
 
     /** Gets the stub {@link Dispatcher}. */
     public static Dispatcher get() {
         return instance;
     }
 
-    @Override
-    public boolean isInIoThread() {
-        return true;
+    /** Creates the stub {@link Dispatcher}. */
+    private static Dispatcher create() {
+        Dispatcher dispatcher = mock(Dispatcher.class);
+        when(dispatcher.isInIoThread()).thenReturn(true);
+        ScheduledExecutor ioThread = createStubIoThread();
+        when(dispatcher.getIoThread()).thenReturn(ioThread);
+        ExecutorService worker = createStubWorker();
+        when(dispatcher.getWorker()).thenReturn(worker);
+        return dispatcher;
     }
-
-    @Override
-    public ScheduledExecutor getIoThread() {
-        return ioThread;
-    }
-
-    @Override
-    public ExecutorService getWorker() {
-        return worker;
-    }
-
-    @Override
-    public <S extends Sender> void dispatch(S sender, ApiHandler<S> handler) {}
-
-    @Override
-    public void dispatched() {}
-
-    @Override
-    public <S extends Sender> void executeHandler(S sender, ApiHandler<S> handler) {}
 
     /** Creates a stub {@link ScheduledExecutor} for the IO thread. */
     private static ScheduledExecutor createStubIoThread() {
@@ -75,6 +57,7 @@ public final class StubDispatcher implements Dispatcher {
         return worker;
     }
 
+    // static class
     private StubDispatcher() {}
 
     /** Stub future whose value cannot be retrieved. */

--- a/infra/api/src/main/java/org/example/age/api/infra/UndertowDispatcher.java
+++ b/infra/api/src/main/java/org/example/age/api/infra/UndertowDispatcher.java
@@ -5,6 +5,7 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.SameThreadExecutor;
 import java.util.concurrent.ExecutorService;
 import org.example.age.api.base.ApiHandler;
+import org.example.age.api.base.DispatchedHandler;
 import org.example.age.api.base.Dispatcher;
 import org.example.age.api.base.ScheduledExecutor;
 import org.example.age.api.base.Sender;
@@ -37,8 +38,30 @@ public final class UndertowDispatcher implements Dispatcher {
     }
 
     @Override
-    public <S extends Sender> void dispatch(S sender, ApiHandler<S> handler) {
+    public <S extends Sender> void dispatch(S sender, ApiHandler.ZeroArg<S> handler) {
         exchange.dispatch(ex -> handler.handleRequest(sender, this));
+    }
+
+    @Override
+    public <S extends Sender, A> void dispatch(S sender, A arg, ApiHandler.OneArg<S, A> handler) {
+        exchange.dispatch(ex -> handler.handleRequest(sender, arg, this));
+    }
+
+    @Override
+    public <S extends Sender, A1, A2> void dispatch(S sender, A1 arg1, A2 arg2, ApiHandler.TwoArg<S, A1, A2> handler) {
+        exchange.dispatch(ex -> handler.handleRequest(sender, arg1, arg2, this));
+    }
+
+    @Override
+    public <S extends Sender, A1, A2, A3> void dispatch(
+            S sender, A1 arg1, A2 arg2, A3 arg3, ApiHandler.ThreeArg<S, A1, A2, A3> handler) {
+        exchange.dispatch(ex -> handler.handleRequest(sender, arg1, arg2, arg3, this));
+    }
+
+    @Override
+    public <S extends Sender, A1, A2, A3, A4> void dispatch(
+            S sender, A1 arg1, A2 arg2, A3 arg3, A4 arg4, ApiHandler.FourArg<S, A1, A2, A3, A4> handler) {
+        exchange.dispatch(ex -> handler.handleRequest(sender, arg1, arg2, arg3, arg4, this));
     }
 
     @Override
@@ -47,8 +70,8 @@ public final class UndertowDispatcher implements Dispatcher {
     }
 
     @Override
-    public <S extends Sender> void executeHandler(S sender, ApiHandler<S> handler) {
-        Connectors.executeRootHandler(ex -> handler.handleRequest(sender, this), exchange);
+    public <S extends Sender> void executeHandler(DispatchedHandler handler) {
+        Connectors.executeRootHandler(ex -> handler.handleRequest(), exchange);
     }
 
     private UndertowDispatcher(HttpServerExchange exchange) {

--- a/infra/api/src/test/java/org/example/age/api/infra/UndertowDispatcherTest.java
+++ b/infra/api/src/test/java/org/example/age/api/infra/UndertowDispatcherTest.java
@@ -78,18 +78,22 @@ public final class UndertowDispatcherTest {
                 case "/dispatched-io-thread":
                     dispatcher
                             .getIoThread()
-                            .execute(() -> dispatcher.executeHandler(sender, TestHandler::ioThreadHandler));
+                            .execute(() -> dispatcher.executeHandler(() -> ioThreadHandler(sender, dispatcher)));
                     dispatcher.dispatched();
                     return;
                 case "/dispatched-worker":
-                    dispatcher.getWorker().execute(() -> dispatcher.executeHandler(sender, TestHandler::workerHandler));
+                    dispatcher
+                            .getWorker()
+                            .execute(() -> dispatcher.executeHandler(() -> workerHandler(sender, dispatcher)));
                     dispatcher.dispatched();
                     return;
                 case "/error-dispatch":
                     dispatcher.dispatch(sender, TestHandler::badHandler);
                     return;
                 case "/error-dispatched":
-                    dispatcher.getWorker().execute(() -> dispatcher.executeHandler(sender, TestHandler::badHandler));
+                    dispatcher
+                            .getWorker()
+                            .execute(() -> dispatcher.executeHandler(() -> badHandler(sender, dispatcher)));
                     dispatcher.dispatched();
                     return;
                 default:

--- a/infra/service/src/main/java/org/example/age/infra/service/client/RequestDispatcherImpl.java
+++ b/infra/service/src/main/java/org/example/age/infra/service/client/RequestDispatcherImpl.java
@@ -90,7 +90,7 @@ final class RequestDispatcherImpl implements RequestDispatcher {
 
         @Override
         public final void onResponse(Call call, Response response) {
-            dispatcher.executeHandler(sender, (s, d) -> handleResponse(s, response, d));
+            dispatcher.executeHandler(() -> handleResponse(sender, response, dispatcher));
         }
 
         @Override

--- a/infra/service/src/test/java/org/example/age/infra/service/client/internal/ExchangeClientTest.java
+++ b/infra/service/src/test/java/org/example/age/infra/service/client/internal/ExchangeClientTest.java
@@ -77,7 +77,7 @@ public final class ExchangeClientTest {
 
             @Override
             public void onResponse(Call call, Response response) {
-                dispatcher.executeHandler(sender, (s, d) -> onRecipientReceived(s, response));
+                dispatcher.executeHandler(() -> onRecipientReceived(sender, response));
             }
 
             @Override


### PR DESCRIPTION
- We stop at 4 args; the next power of 2 (8) is overkill for a proof-of-concept.
- `Dispatcher` is also changed to accept all 5 variants.
- Related: If a request is manually dispatched (i.e., `dispatched()` is called) a simple `DispatchedHandler` is used.