### PR TITLE
adapt an API handler to a handler for the underlying server

### DIFF
--- a/api/adapter/build.gradle.kts
+++ b/api/adapter/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("org.example.age.java-conventions")
+    `java-library`
+}
+
+dependencies {
+    // main
+    api(project(":api:base"))
+
+    // test
+    testImplementation(testFixtures(project(":api:base")))
+}

--- a/api/adapter/src/main/java/org/example/age/api/adapter/AdaptedApiHandler.java
+++ b/api/adapter/src/main/java/org/example/age/api/adapter/AdaptedApiHandler.java
@@ -1,0 +1,324 @@
+package org.example.age.api.adapter;
+
+import java.util.List;
+import org.example.age.api.base.ApiHandler;
+import org.example.age.api.base.Sender;
+
+/**
+ * Adapts an {@link ApiHandler} to a handler for the underlying server.
+ *
+ * <p>In practice, consumers will create a specialized builder that is backed by {@link ApiHandler}'s builder.</p>
+ */
+public abstract class AdaptedApiHandler<E> {
+
+    /** Creates a builder for an {@link AdaptedApiHandler}. */
+    public static <E, S extends Sender> ZeroArgBuilder<E, S> builder(
+            SenderFactory<E, S> senderFactory, DispatcherFactory<E> dispatcherFactory) {
+        return new ZeroArgBuilder<>(senderFactory, dispatcherFactory);
+    }
+
+    public abstract void handleRequest(E exchange) throws Exception;
+
+    /** Handles the underlying request using the callback. */
+    protected static <E, S extends Sender, A1, A2, A3, A4> void handleRequest(
+            E exchange, AdapterCallback<E, S, A1, A2, A3, A4> callback) throws Exception {
+        ApiRequest<S, A1, A2, A3, A4> apiRequest = new ApiRequest<>();
+        callback.handleRequest(exchange, apiRequest);
+    }
+
+    private AdaptedApiHandler() {}
+
+    /** Builder for an {@link AdaptedApiHandler} with zero or more arguments. */
+    public static final class ZeroArgBuilder<E, S extends Sender> implements ArgBuilder<E, ApiHandler.ZeroArg<S>> {
+
+        private final SenderFactory<E, S> senderFactory;
+        private final DispatcherFactory<E> dispatcherFactory;
+
+        @Override
+        public AdaptedApiHandler<E> build(ApiHandler.ZeroArg<S> apiHandler) {
+            return new ZeroArg<>(apiHandler, senderFactory, dispatcherFactory);
+        }
+
+        @Override
+        public <A1> OneArgBuilder<E, S, A1> addExtractor(Extractor.Async<E, A1> extractor) {
+            return new OneArgBuilder<>(this, extractor);
+        }
+
+        @Override
+        public <A1> OneArgBuilder<E, S, A1> addExtractor(Extractor<E, A1> extractor) {
+            return addExtractor(extractor.async());
+        }
+
+        private ZeroArgBuilder(SenderFactory<E, S> senderFactory, DispatcherFactory<E> dispatcherFactory) {
+            this.senderFactory = senderFactory;
+            this.dispatcherFactory = dispatcherFactory;
+        }
+    }
+
+    /** Builder for an {@link AdaptedApiHandler} with one or more arguments. */
+    public static final class OneArgBuilder<E, S extends Sender, A1>
+            implements ArgBuilder<E, ApiHandler.OneArg<S, A1>> {
+
+        private final ZeroArgBuilder<E, S> builder0;
+        private final Extractor.Async<E, A1> extractor;
+
+        @Override
+        public AdaptedApiHandler<E> build(ApiHandler.OneArg<S, A1> apiHandler) {
+            return new OneArg<>(apiHandler, builder0.senderFactory, builder0.dispatcherFactory, extractor);
+        }
+
+        @Override
+        public <A2> TwoArgBuilder<E, S, A1, A2> addExtractor(Extractor.Async<E, A2> extractor) {
+            return new TwoArgBuilder<>(this, extractor);
+        }
+
+        @Override
+        public <A2> TwoArgBuilder<E, S, A1, A2> addExtractor(Extractor<E, A2> extractor) {
+            return addExtractor(extractor.async());
+        }
+
+        private OneArgBuilder(ZeroArgBuilder<E, S> builder0, Extractor.Async<E, A1> extractor) {
+            this.builder0 = builder0;
+            this.extractor = extractor;
+        }
+    }
+
+    /** Builder for an {@link AdaptedApiHandler} with two or more arguments. */
+    public static final class TwoArgBuilder<E, S extends Sender, A1, A2>
+            implements ArgBuilder<E, ApiHandler.TwoArg<S, A1, A2>> {
+
+        private final OneArgBuilder<E, S, A1> builder1;
+        private final Extractor.Async<E, A2> extractor;
+
+        @Override
+        public AdaptedApiHandler<E> build(ApiHandler.TwoArg<S, A1, A2> apiHandler) {
+            ZeroArgBuilder<E, S> builder0 = builder1.builder0;
+            return new TwoArg<>(
+                    apiHandler, builder0.senderFactory, builder0.dispatcherFactory, builder1.extractor, extractor);
+        }
+
+        @Override
+        public <A3> ThreeArgBuilder<E, S, A1, A2, A3> addExtractor(Extractor.Async<E, A3> extractor) {
+            return new ThreeArgBuilder<>(this, extractor);
+        }
+
+        @Override
+        public <A3> ThreeArgBuilder<E, S, A1, A2, A3> addExtractor(Extractor<E, A3> extractor) {
+            return addExtractor(extractor.async());
+        }
+
+        private TwoArgBuilder(OneArgBuilder<E, S, A1> builder1, Extractor.Async<E, A2> extractor) {
+            this.builder1 = builder1;
+            this.extractor = extractor;
+        }
+    }
+
+    /** Builder for an {@link AdaptedApiHandler} with three or more arguments. */
+    public static final class ThreeArgBuilder<E, S extends Sender, A1, A2, A3>
+            implements ArgBuilder<E, ApiHandler.ThreeArg<S, A1, A2, A3>> {
+
+        private final TwoArgBuilder<E, S, A1, A2> builder2;
+        private final Extractor.Async<E, A3> extractor;
+
+        @Override
+        public AdaptedApiHandler<E> build(ApiHandler.ThreeArg<S, A1, A2, A3> apiHandler) {
+            OneArgBuilder<E, S, A1> builder1 = builder2.builder1;
+            ZeroArgBuilder<E, S> builder0 = builder1.builder0;
+            return new ThreeArg<>(
+                    apiHandler,
+                    builder0.senderFactory,
+                    builder0.dispatcherFactory,
+                    builder1.extractor,
+                    builder2.extractor,
+                    extractor);
+        }
+
+        @Override
+        public <A4> FourArgBuilder<E, S, A1, A2, A3, A4> addExtractor(Extractor.Async<E, A4> extractor) {
+            return new FourArgBuilder<>(this, extractor);
+        }
+
+        @Override
+        public <A4> FourArgBuilder<E, S, A1, A2, A3, A4> addExtractor(Extractor<E, A4> extractor) {
+            return addExtractor(extractor.async());
+        }
+
+        private ThreeArgBuilder(TwoArgBuilder<E, S, A1, A2> builder2, Extractor.Async<E, A3> extractor) {
+            this.builder2 = builder2;
+            this.extractor = extractor;
+        }
+    }
+
+    /** Builder for an {@link AdaptedApiHandler} with four arguments. */
+    public static final class FourArgBuilder<E, S extends Sender, A1, A2, A3, A4>
+            implements Builder<E, ApiHandler.FourArg<S, A1, A2, A3, A4>> {
+
+        private final ThreeArgBuilder<E, S, A1, A2, A3> builder3;
+        private final Extractor.Async<E, A4> extractor;
+
+        @Override
+        public AdaptedApiHandler<E> build(ApiHandler.FourArg<S, A1, A2, A3, A4> apiHandler) {
+            TwoArgBuilder<E, S, A1, A2> builder2 = builder3.builder2;
+            OneArgBuilder<E, S, A1> builder1 = builder2.builder1;
+            ZeroArgBuilder<E, S> builder0 = builder1.builder0;
+            return new FourArg<>(
+                    apiHandler,
+                    builder0.senderFactory,
+                    builder0.dispatcherFactory,
+                    builder1.extractor,
+                    builder2.extractor,
+                    builder3.extractor,
+                    extractor);
+        }
+
+        private FourArgBuilder(ThreeArgBuilder<E, S, A1, A2, A3> builder3, Extractor.Async<E, A4> extractor) {
+            this.builder3 = builder3;
+            this.extractor = extractor;
+        }
+    }
+
+    /** Adapts an {@link ApiHandler.ZeroArg} to a handler for the underlying server. */
+    public static final class ZeroArg<E, S extends Sender> extends AdaptedApiHandler<E> {
+
+        private final AdapterCallback<E, S, Void, Void, Void, Void> callback;
+
+        @Override
+        public void handleRequest(E exchange) throws Exception {
+            handleRequest(exchange, callback);
+        }
+
+        private ZeroArg(
+                ApiHandler.ZeroArg<S> apiHandler,
+                SenderFactory<E, S> senderFactory,
+                DispatcherFactory<E> dispatcherFactory) {
+            callback = AdapterCallbacks.chain(
+                    AdapterCallbacks.zeroArgInvoker(apiHandler),
+                    List.of(AdapterCallbacks.init(senderFactory, dispatcherFactory)));
+        }
+    }
+
+    /** Adapts an {@link ApiHandler.OneArg} to a handler for the underlying server. */
+    public static final class OneArg<E, S extends Sender, A> extends AdaptedApiHandler<E> {
+
+        private final AdapterCallback<E, S, A, Void, Void, Void> callback;
+
+        @Override
+        public void handleRequest(E exchange) throws Exception {
+            handleRequest(exchange, callback);
+        }
+
+        private OneArg(
+                ApiHandler.OneArg<S, A> apiHandler,
+                SenderFactory<E, S> senderFactory,
+                DispatcherFactory<E> dispatcherFactory,
+                Extractor.Async<E, A> argExtractor) {
+            callback = AdapterCallbacks.chain(
+                    AdapterCallbacks.oneArgInvoker(apiHandler),
+                    List.of(
+                            AdapterCallbacks.init(senderFactory, dispatcherFactory),
+                            AdapterCallbacks.arg1(argExtractor)));
+        }
+    }
+
+    /** Adapts an {@link ApiHandler.TwoArg} to a handler for the underlying server. */
+    public static final class TwoArg<E, S extends Sender, A1, A2> extends AdaptedApiHandler<E> {
+
+        private final AdapterCallback<E, S, A1, A2, Void, Void> callback;
+
+        @Override
+        public void handleRequest(E exchange) throws Exception {
+            handleRequest(exchange, callback);
+        }
+
+        private TwoArg(
+                ApiHandler.TwoArg<S, A1, A2> apiHandler,
+                SenderFactory<E, S> senderFactory,
+                DispatcherFactory<E> dispatcherFactory,
+                Extractor.Async<E, A1> arg1Extractor,
+                Extractor.Async<E, A2> arg2Extractor) {
+            callback = AdapterCallbacks.chain(
+                    AdapterCallbacks.twoArgInvoker(apiHandler),
+                    List.of(
+                            AdapterCallbacks.init(senderFactory, dispatcherFactory),
+                            AdapterCallbacks.arg1(arg1Extractor),
+                            AdapterCallbacks.arg2(arg2Extractor)));
+        }
+    }
+
+    /** Adapts an {@link ApiHandler.ThreeArg} to a handler for the underlying server. */
+    public static final class ThreeArg<E, S extends Sender, A1, A2, A3> extends AdaptedApiHandler<E> {
+
+        private final AdapterCallback<E, S, A1, A2, A3, Void> callback;
+
+        @Override
+        public void handleRequest(E exchange) throws Exception {
+            handleRequest(exchange, callback);
+        }
+
+        private ThreeArg(
+                ApiHandler.ThreeArg<S, A1, A2, A3> apiHandler,
+                SenderFactory<E, S> senderFactory,
+                DispatcherFactory<E> dispatcherFactory,
+                Extractor.Async<E, A1> arg1Extractor,
+                Extractor.Async<E, A2> arg2Extractor,
+                Extractor.Async<E, A3> arg3Extractor) {
+            callback = AdapterCallbacks.chain(
+                    AdapterCallbacks.threeArgInvoker(apiHandler),
+                    List.of(
+                            AdapterCallbacks.init(senderFactory, dispatcherFactory),
+                            AdapterCallbacks.arg1(arg1Extractor),
+                            AdapterCallbacks.arg2(arg2Extractor),
+                            AdapterCallbacks.arg3(arg3Extractor)));
+        }
+    }
+
+    /** Adapts an {@link ApiHandler.FourArg} to a handler for the underlying server. */
+    public static final class FourArg<E, S extends Sender, A1, A2, A3, A4> extends AdaptedApiHandler<E> {
+
+        private final AdapterCallback<E, S, A1, A2, A3, A4> callback;
+
+        @Override
+        public void handleRequest(E exchange) throws Exception {
+            handleRequest(exchange, callback);
+        }
+
+        private FourArg(
+                ApiHandler.FourArg<S, A1, A2, A3, A4> apiHandler,
+                SenderFactory<E, S> senderFactory,
+                DispatcherFactory<E> dispatcherFactory,
+                Extractor.Async<E, A1> arg1Extractor,
+                Extractor.Async<E, A2> arg2Extractor,
+                Extractor.Async<E, A3> arg3Extractor,
+                Extractor.Async<E, A4> arg4Extractor) {
+            callback = AdapterCallbacks.chain(
+                    AdapterCallbacks.fourArgInvoker(apiHandler),
+                    List.of(
+                            AdapterCallbacks.init(senderFactory, dispatcherFactory),
+                            AdapterCallbacks.arg1(arg1Extractor),
+                            AdapterCallbacks.arg2(arg2Extractor),
+                            AdapterCallbacks.arg3(arg3Extractor),
+                            AdapterCallbacks.arg4(arg4Extractor)));
+        }
+    }
+
+    /** Builder for an {@link AdaptedApiHandler}. */
+    private interface Builder<E, H> {
+
+        /** Builds an {@link AdaptedApiHandler} that invokes an {@link ApiHandler}. */
+        AdaptedApiHandler<E> build(H apiHandler);
+    }
+
+    /**
+     * Builder for an {@link AdaptedApiHandler} that can add another argument.
+     *
+     * <p>Implementations will override the return type.</p>
+     */
+    private interface ArgBuilder<E, H> extends Builder<E, H> {
+
+        /** Adds an argument that is extracted from the underlying request. */
+        <A> Object addExtractor(Extractor.Async<E, A> extractor);
+
+        /** Adds an argument that is extracted from the underlying request. */
+        <A> Object addExtractor(Extractor<E, A> extractor);
+    }
+}

--- a/api/adapter/src/main/java/org/example/age/api/adapter/AdapterCallback.java
+++ b/api/adapter/src/main/java/org/example/age/api/adapter/AdapterCallback.java
@@ -1,0 +1,20 @@
+package org.example.age.api.adapter;
+
+import org.example.age.api.base.Sender;
+
+/** Internal callback used to build an {@link ApiRequest} from the underlying exchange. */
+@FunctionalInterface
+interface AdapterCallback<E, S extends Sender, A1, A2, A3, A4> {
+
+    void handleRequest(E exchange, ApiRequest<S, A1, A2, A3, A4> apiRequest) throws Exception;
+
+    /** {@link AdapterCallback} that is chained to another {@link AdapterCallback}. */
+    abstract class Chained<E, S extends Sender, A1, A2, A3, A4> implements AdapterCallback<E, S, A1, A2, A3, A4> {
+
+        protected AdapterCallback<E, S, A1, A2, A3, A4> next = null;
+
+        public final void setNext(AdapterCallback<E, S, A1, A2, A3, A4> next) {
+            this.next = next;
+        }
+    }
+}

--- a/api/adapter/src/main/java/org/example/age/api/adapter/AdapterCallbacks.java
+++ b/api/adapter/src/main/java/org/example/age/api/adapter/AdapterCallbacks.java
@@ -1,0 +1,256 @@
+package org.example.age.api.adapter;
+
+import java.util.List;
+import org.example.age.api.base.ApiHandler;
+import org.example.age.api.base.Dispatcher;
+import org.example.age.api.base.HttpOptional;
+import org.example.age.api.base.Sender;
+
+/** Repository of {@link AdapterCallback}'s that can be chained together. */
+final class AdapterCallbacks {
+
+    /** Chains the callbacks together, returning a single callback. */
+    public static <E, S extends Sender, A1, A2, A3, A4> AdapterCallback<E, S, A1, A2, A3, A4> chain(
+            AdapterCallback<E, S, A1, A2, A3, A4> invoker,
+            List<AdapterCallback.Chained<E, S, A1, A2, A3, A4>> callbackChain) {
+        AdapterCallback<E, S, A1, A2, A3, A4> callback = invoker;
+        for (int index = callbackChain.size() - 1; index >= 0; index--) {
+            AdapterCallback.Chained<E, S, A1, A2, A3, A4> chainedCallback = callbackChain.get(index);
+            chainedCallback.setNext(callback);
+            callback = chainedCallback;
+        }
+        return callback;
+    }
+
+    /** Creates an {@link AdapterCallback} that invokes an {@link ApiHandler.ZeroArg}. */
+    public static <E, S extends Sender> AdapterCallback<E, S, Void, Void, Void, Void> zeroArgInvoker(
+            ApiHandler.ZeroArg<S> apiHandler) {
+        return new ZeroArgInvoker<>(apiHandler);
+    }
+
+    /** Creates an {@link AdapterCallback} that invokes an {@link ApiHandler.OneArg}. */
+    public static <E, S extends Sender, A> AdapterCallback<E, S, A, Void, Void, Void> oneArgInvoker(
+            ApiHandler.OneArg<S, A> apiHandler) {
+        return new OneArgInvoker<>(apiHandler);
+    }
+
+    /** Creates an {@link AdapterCallback} that invokes an {@link ApiHandler.TwoArg}. */
+    public static <E, S extends Sender, A1, A2> AdapterCallback<E, S, A1, A2, Void, Void> twoArgInvoker(
+            ApiHandler.TwoArg<S, A1, A2> apiHandler) {
+        return new TwoArgInvoker<>(apiHandler);
+    }
+
+    /** Creates an {@link AdapterCallback} that invokes an {@link ApiHandler.ThreeArg}. */
+    public static <E, S extends Sender, A1, A2, A3> AdapterCallback<E, S, A1, A2, A3, Void> threeArgInvoker(
+            ApiHandler.ThreeArg<S, A1, A2, A3> apiHandler) {
+        return new ThreeArgInvoker<>(apiHandler);
+    }
+
+    /** Creates an {@link AdapterCallback} that invokes an {@link ApiHandler.FourArg}. */
+    public static <E, S extends Sender, A1, A2, A3, A4> AdapterCallback<E, S, A1, A2, A3, A4> fourArgInvoker(
+            ApiHandler.FourArg<S, A1, A2, A3, A4> apiHandler) {
+        return new FourArgInvoker<>(apiHandler);
+    }
+
+    /**
+     * Creates an {@link AdapterCallback.Chained} that creates the {@link Sender} and the {@link Dispatcher}.
+     *
+     * <p>This callback must run first; subsequent callbacks may use the {@link Sender}.</p>
+     */
+    public static <E, S extends Sender, A1, A2, A3, A4> AdapterCallback.Chained<E, S, A1, A2, A3, A4> init(
+            SenderFactory<E, S> senderFactory, DispatcherFactory<E> dispatcherFactory) {
+        return new InitCallback<>(senderFactory, dispatcherFactory);
+    }
+
+    /** Creates an {@link AdapterCallback.Chained} that extracts the first argument. */
+    public static <E, S extends Sender, A1, A2, A3, A4> AdapterCallback.Chained<E, S, A1, A2, A3, A4> arg1(
+            Extractor.Async<E, A1> arg1Extractor) {
+        return new Arg1Callback<>(arg1Extractor);
+    }
+
+    /** Creates an {@link AdapterCallback.Chained} that extracts the second argument. */
+    public static <E, S extends Sender, A1, A2, A3, A4> AdapterCallback.Chained<E, S, A1, A2, A3, A4> arg2(
+            Extractor.Async<E, A2> arg2Extractor) {
+        return new Arg2Callback<>(arg2Extractor);
+    }
+
+    /** Creates an {@link AdapterCallback.Chained} that extracts the third argument. */
+    public static <E, S extends Sender, A1, A2, A3, A4> AdapterCallback.Chained<E, S, A1, A2, A3, A4> arg3(
+            Extractor.Async<E, A3> arg3Extractor) {
+        return new Arg3Callback<>(arg3Extractor);
+    }
+
+    /** Creates an {@link AdapterCallback.Chained} that extracts the fourth argument. */
+    public static <E, S extends Sender, A1, A2, A3, A4> AdapterCallback.Chained<E, S, A1, A2, A3, A4> arg4(
+            Extractor.Async<E, A4> arg4Extractor) {
+        return new Arg4Callback<>(arg4Extractor);
+    }
+
+    // static class
+    private AdapterCallbacks() {}
+
+    /** Terminal callback that invokes an {@link ApiHandler.ZeroArg}. */
+    private record ZeroArgInvoker<E, S extends Sender>(ApiHandler.ZeroArg<S> apiHandler)
+            implements AdapterCallback<E, S, Void, Void, Void, Void> {
+
+        @Override
+        public void handleRequest(E exchange, ApiRequest<S, Void, Void, Void, Void> apiRequest) throws Exception {
+            apiHandler.handleRequest(apiRequest.sender, apiRequest.dispatcher);
+        }
+    }
+
+    /** Terminal callback that invokes an {@link ApiHandler.OneArg}. */
+    private record OneArgInvoker<E, S extends Sender, A>(ApiHandler.OneArg<S, A> apiHandler)
+            implements AdapterCallback<E, S, A, Void, Void, Void> {
+
+        @Override
+        public void handleRequest(E exchange, ApiRequest<S, A, Void, Void, Void> apiRequest) throws Exception {
+            apiHandler.handleRequest(apiRequest.sender, apiRequest.arg1, apiRequest.dispatcher);
+        }
+    }
+
+    /** Terminal callback that invokes an {@link ApiHandler.TwoArg}. */
+    private record TwoArgInvoker<E, S extends Sender, A1, A2>(ApiHandler.TwoArg<S, A1, A2> apiHandler)
+            implements AdapterCallback<E, S, A1, A2, Void, Void> {
+
+        @Override
+        public void handleRequest(E exchange, ApiRequest<S, A1, A2, Void, Void> apiRequest) throws Exception {
+            apiHandler.handleRequest(apiRequest.sender, apiRequest.arg1, apiRequest.arg2, apiRequest.dispatcher);
+        }
+    }
+
+    /** Terminal callback that invokes an {@link ApiHandler.ThreeArg}. */
+    private record ThreeArgInvoker<E, S extends Sender, A1, A2, A3>(ApiHandler.ThreeArg<S, A1, A2, A3> apiHandler)
+            implements AdapterCallback<E, S, A1, A2, A3, Void> {
+
+        @Override
+        public void handleRequest(E exchange, ApiRequest<S, A1, A2, A3, Void> apiRequest) throws Exception {
+            apiHandler.handleRequest(
+                    apiRequest.sender, apiRequest.arg1, apiRequest.arg2, apiRequest.arg3, apiRequest.dispatcher);
+        }
+    }
+
+    /** Terminal callback that invokes an {@link ApiHandler.FourArg}. */
+    private record FourArgInvoker<E, S extends Sender, A1, A2, A3, A4>(ApiHandler.FourArg<S, A1, A2, A3, A4> apiHandler)
+            implements AdapterCallback<E, S, A1, A2, A3, A4> {
+
+        @Override
+        public void handleRequest(E exchange, ApiRequest<S, A1, A2, A3, A4> apiRequest) throws Exception {
+            apiHandler.handleRequest(
+                    apiRequest.sender,
+                    apiRequest.arg1,
+                    apiRequest.arg2,
+                    apiRequest.arg3,
+                    apiRequest.arg4,
+                    apiRequest.dispatcher);
+        }
+    }
+
+    /** Chained callback the creates the {@link Sender} and the {@link Dispatcher}. */
+    private static final class InitCallback<E, S extends Sender, A1, A2, A3, A4>
+            extends AdapterCallback.Chained<E, S, A1, A2, A3, A4> {
+
+        private final SenderFactory<E, S> senderFactory;
+        private final DispatcherFactory<E> dispatcherFactory;
+
+        @Override
+        public void handleRequest(E exchange, ApiRequest<S, A1, A2, A3, A4> apiRequest) throws Exception {
+            apiRequest.sender = senderFactory.create(exchange);
+            apiRequest.dispatcher = dispatcherFactory.create(exchange);
+            next.handleRequest(exchange, apiRequest);
+        }
+
+        private InitCallback(SenderFactory<E, S> senderFactory, DispatcherFactory<E> dispatcherFactory) {
+            this.senderFactory = senderFactory;
+            this.dispatcherFactory = dispatcherFactory;
+        }
+    }
+
+    /** Chained callback that extracts an argument. */
+    private abstract static class ArgCallback<E, S extends Sender, A1, A2, A3, A4, A>
+            extends AdapterCallback.Chained<E, S, A1, A2, A3, A4> {
+
+        private final Extractor.Async<E, A> argExtractor;
+
+        @Override
+        public final void handleRequest(E exchange, ApiRequest<S, A1, A2, A3, A4> apiRequest) throws Exception {
+            argExtractor.tryExtract(exchange, maybeArg -> onArgExtracted(exchange, apiRequest, maybeArg));
+        }
+
+        /** Sets the argument in the {@link ApiRequest}. */
+        protected abstract void setArg(ApiRequest<S, A1, A2, A3, A4> apiRequest, A arg);
+
+        protected ArgCallback(Extractor.Async<E, A> argExtractor) {
+            this.argExtractor = argExtractor;
+        }
+
+        /** Called when the argument has been extracted. */
+        private void onArgExtracted(E exchange, ApiRequest<S, A1, A2, A3, A4> apiRequest, HttpOptional<A> maybeArg)
+                throws Exception {
+            if (maybeArg.isEmpty()) {
+                apiRequest.sender.sendErrorCode(maybeArg.statusCode());
+                return;
+            }
+            A arg = maybeArg.get();
+
+            setArg(apiRequest, arg);
+            next.handleRequest(exchange, apiRequest);
+        }
+    }
+
+    /** Chained callback that extracts the first argument. */
+    private static final class Arg1Callback<E, S extends Sender, A1, A2, A3, A4>
+            extends ArgCallback<E, S, A1, A2, A3, A4, A1> {
+
+        @Override
+        protected void setArg(ApiRequest<S, A1, A2, A3, A4> apiRequest, A1 arg1) {
+            apiRequest.arg1 = arg1;
+        }
+
+        private Arg1Callback(Extractor.Async<E, A1> arg1Extractor) {
+            super(arg1Extractor);
+        }
+    }
+
+    /** Chained callback that extracts the second argument. */
+    private static final class Arg2Callback<E, S extends Sender, A1, A2, A3, A4>
+            extends ArgCallback<E, S, A1, A2, A3, A4, A2> {
+
+        @Override
+        protected void setArg(ApiRequest<S, A1, A2, A3, A4> apiRequest, A2 arg2) {
+            apiRequest.arg2 = arg2;
+        }
+
+        private Arg2Callback(Extractor.Async<E, A2> arg2Extractor) {
+            super(arg2Extractor);
+        }
+    }
+
+    /** Chained callback that extracts the third argument. */
+    private static final class Arg3Callback<E, S extends Sender, A1, A2, A3, A4>
+            extends ArgCallback<E, S, A1, A2, A3, A4, A3> {
+
+        @Override
+        protected void setArg(ApiRequest<S, A1, A2, A3, A4> apiRequest, A3 arg3) {
+            apiRequest.arg3 = arg3;
+        }
+
+        private Arg3Callback(Extractor.Async<E, A3> arg3Extractor) {
+            super(arg3Extractor);
+        }
+    }
+
+    /** Chained callback that extracts the fourth argument. */
+    private static final class Arg4Callback<E, S extends Sender, A1, A2, A3, A4>
+            extends ArgCallback<E, S, A1, A2, A3, A4, A4> {
+
+        @Override
+        protected void setArg(ApiRequest<S, A1, A2, A3, A4> apiRequest, A4 arg4) {
+            apiRequest.arg4 = arg4;
+        }
+
+        private Arg4Callback(Extractor.Async<E, A4> arg4Extractor) {
+            super(arg4Extractor);
+        }
+    }
+}

--- a/api/adapter/src/main/java/org/example/age/api/adapter/ApiRequest.java
+++ b/api/adapter/src/main/java/org/example/age/api/adapter/ApiRequest.java
@@ -1,0 +1,18 @@
+package org.example.age.api.adapter;
+
+import org.example.age.api.base.Dispatcher;
+import org.example.age.api.base.Sender;
+
+/**
+ * Internal data structure for an API request.
+ *
+ * <p>Some type parameters may be {@link Void}, depending on how many arguments the API request actually has.</p>
+ */
+final class ApiRequest<S extends Sender, A1, A2, A3, A4> {
+    public S sender = null;
+    public Dispatcher dispatcher = null;
+    public A1 arg1 = null;
+    public A2 arg2 = null;
+    public A3 arg3 = null;
+    public A4 arg4 = null;
+}

--- a/api/adapter/src/main/java/org/example/age/api/adapter/DispatcherFactory.java
+++ b/api/adapter/src/main/java/org/example/age/api/adapter/DispatcherFactory.java
@@ -1,0 +1,10 @@
+package org.example.age.api.adapter;
+
+import org.example.age.api.base.Dispatcher;
+
+/** Creates a {@link Dispatcher} from the underlying exchange. */
+@FunctionalInterface
+public interface DispatcherFactory<E> {
+
+    Dispatcher create(E exchange);
+}

--- a/api/adapter/src/main/java/org/example/age/api/adapter/Extractor.java
+++ b/api/adapter/src/main/java/org/example/age/api/adapter/Extractor.java
@@ -1,0 +1,36 @@
+package org.example.age.api.adapter;
+
+import org.example.age.api.base.HttpOptional;
+
+/** Synchronously extracts a value (or an error status code) from the underlying request. */
+@FunctionalInterface
+public interface Extractor<E, V> {
+
+    HttpOptional<V> tryExtract(E exchange);
+
+    /** Adapts this extractor to the asynchronous interface. */
+    default Async<E, V> async() {
+        return (exchange, callback) -> {
+            HttpOptional<V> maybeValue = tryExtract(exchange);
+            callback.onValueExtracted(maybeValue);
+        };
+    }
+
+    /**
+     * Asynchronously extracts a value (or an error status code) from the underlying request.
+     *
+     * <p>An implementation may be synchronous or asynchronous.</p>
+     */
+    @FunctionalInterface
+    interface Async<E, V> {
+
+        void tryExtract(E exchange, Callback<V> callback) throws Exception;
+    }
+
+    /** Called when a value (or an error status code) has been extracted from the underlying request. */
+    @FunctionalInterface
+    interface Callback<V> {
+
+        void onValueExtracted(HttpOptional<V> maybeValue) throws Exception;
+    }
+}

--- a/api/adapter/src/main/java/org/example/age/api/adapter/SenderFactory.java
+++ b/api/adapter/src/main/java/org/example/age/api/adapter/SenderFactory.java
@@ -1,0 +1,10 @@
+package org.example.age.api.adapter;
+
+import org.example.age.api.base.Sender;
+
+/** Creates a {@link Sender} from the underlying exchange. */
+@FunctionalInterface
+public interface SenderFactory<E, S extends Sender> {
+
+    S create(E exchange);
+}

--- a/api/adapter/src/test/java/org/example/age/api/adapter/AdaptedApiHandlerTest.java
+++ b/api/adapter/src/test/java/org/example/age/api/adapter/AdaptedApiHandlerTest.java
@@ -1,0 +1,150 @@
+package org.example.age.api.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.example.age.api.base.Dispatcher;
+import org.example.age.api.base.HttpOptional;
+import org.example.age.api.base.ValueSender;
+import org.example.age.testing.api.FakeValueSender;
+import org.example.age.testing.api.StubDispatcher;
+import org.junit.jupiter.api.Test;
+
+public final class AdaptedApiHandlerTest {
+
+    @Test
+    public void handleRequest_ZeroArg() throws Exception {
+        AdaptedApiHandler<TestExchange> handler = AdaptedApiHandler.builder(
+                        TestExchange::sender, TestExchange::dispatcher)
+                .build(AdaptedApiHandlerTest::add0);
+        handleRequest(handler, TestExchange.of(null, null, null, null), 0);
+    }
+
+    @Test
+    public void handleRequest_OneArg() throws Exception {
+        AdaptedApiHandler<TestExchange> handler = AdaptedApiHandler.builder(
+                        TestExchange::sender, TestExchange::dispatcher)
+                .addExtractor(TestExchange::extractOperand1)
+                .build(AdaptedApiHandlerTest::add1);
+        handleRequest(handler, TestExchange.of("1", null, null, null), 1);
+    }
+
+    @Test
+    public void handleRequest_TwoArg() throws Exception {
+        AdaptedApiHandler<TestExchange> handler = AdaptedApiHandler.builder(
+                        TestExchange::sender, TestExchange::dispatcher)
+                .addExtractor(TestExchange::extractOperand1)
+                .addExtractor(TestExchange::extractOperand2)
+                .build(AdaptedApiHandlerTest::add2);
+        handleRequest(handler, TestExchange.of("1", "2", null, null), 3);
+    }
+
+    @Test
+    public void handleRequest_ThreeArg() throws Exception {
+        AdaptedApiHandler<TestExchange> handler = AdaptedApiHandler.builder(
+                        TestExchange::sender, TestExchange::dispatcher)
+                .addExtractor(TestExchange::extractOperand1)
+                .addExtractor(TestExchange::extractOperand2)
+                .addExtractor(TestExchange::extractOperand3)
+                .build(AdaptedApiHandlerTest::add3);
+        handleRequest(handler, TestExchange.of("1", "2", "3", null), 6);
+    }
+
+    @Test
+    public void handleRequest_FourArg() throws Exception {
+        AdaptedApiHandler<TestExchange> handler = AdaptedApiHandler.builder(
+                        TestExchange::sender, TestExchange::dispatcher)
+                .addExtractor(TestExchange::extractOperand1)
+                .addExtractor(TestExchange::extractOperand2)
+                .addExtractor(TestExchange::extractOperand3)
+                .addExtractor(TestExchange::extractOperand4)
+                .build(AdaptedApiHandlerTest::add4);
+        handleRequest(handler, TestExchange.of("1", "2", "3", "4"), 10);
+    }
+
+    private void handleRequest(AdaptedApiHandler<TestExchange> handler, TestExchange exchange, int expectedSum)
+            throws Exception {
+        handler.handleRequest(exchange);
+        assertThat(exchange.sender().tryGet()).hasValue(HttpOptional.of(expectedSum));
+    }
+
+    @Test
+    public void error_HandleRequest_ExtractorFailed() throws Exception {
+        AdaptedApiHandler<TestExchange> handler = AdaptedApiHandler.builder(
+                        TestExchange::sender, TestExchange::dispatcher)
+                .addExtractor(TestExchange::extractOperand1)
+                .build(AdaptedApiHandlerTest::add1);
+        TestExchange exchange = TestExchange.of("a", null, null, null);
+        handler.handleRequest(exchange);
+        assertThat(exchange.sender().tryGet()).hasValue(HttpOptional.empty(400));
+    }
+
+    private static void add0(ValueSender<Integer> sender, Dispatcher dispatcher) {
+        sender.sendValue(0);
+    }
+
+    private static void add1(ValueSender<Integer> sender, int operand, Dispatcher dispatcher) {
+        sender.sendValue(operand);
+    }
+
+    private static void add2(ValueSender<Integer> sender, int operand1, int operand2, Dispatcher dispatcher) {
+        int sum = operand1 + operand2;
+        sender.sendValue(sum);
+    }
+
+    private static void add3(
+            ValueSender<Integer> sender, int operand1, int operand2, int operand3, Dispatcher dispatcher) {
+        int sum = operand1 + operand2 + operand3;
+        sender.sendValue(sum);
+    }
+
+    private static void add4(
+            ValueSender<Integer> sender,
+            int operand1,
+            int operand2,
+            int operand3,
+            int operand4,
+            Dispatcher dispatcher) {
+        int sum = operand1 + operand2 + operand3 + operand4;
+        sender.sendValue(sum);
+    }
+
+    /** Test exchange. */
+    private record TestExchange(
+            FakeValueSender<Integer> sender,
+            Dispatcher dispatcher,
+            String operand1,
+            String operand2,
+            String operand3,
+            String operand4) {
+
+        public static TestExchange of(String operand1, String operand2, String operand3, String operand4) {
+            return new TestExchange(
+                    FakeValueSender.create(), StubDispatcher.get(), operand1, operand2, operand3, operand4);
+        }
+
+        public HttpOptional<Integer> extractOperand1() {
+            return extractInt(operand1);
+        }
+
+        public HttpOptional<Integer> extractOperand2() {
+            return extractInt(operand2);
+        }
+
+        public HttpOptional<Integer> extractOperand3() {
+            return extractInt(operand3);
+        }
+
+        public HttpOptional<Integer> extractOperand4() {
+            return extractInt(operand4);
+        }
+
+        private static HttpOptional<Integer> extractInt(String value) {
+            try {
+                int n = Integer.parseInt(value);
+                return HttpOptional.of(n);
+            } catch (NumberFormatException e) {
+                return HttpOptional.empty(400);
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ rootProject.name = "age-verification"
 include(
         /* generic modules */
         "api:base",
+        "api:adapter",
         "api:data:json",
         "api:data:crypto",
 


### PR DESCRIPTION
- Uses a fluent, type-safe builder.
- Supports asynchronous extraction of the arguments (e.g., reading the request body).
- Is generic and agnostic to the underlying server (and wire format).