### PR TITLE
staged request builder for HTTP clients

### DIFF
--- a/infra/client/src/main/java/org/example/age/client/infra/JsonApiClientImpl.java
+++ b/infra/client/src/main/java/org/example/age/client/infra/JsonApiClientImpl.java
@@ -1,0 +1,119 @@
+package org.example.age.client.infra;
+
+import java.io.IOException;
+import java.util.Map;
+import okhttp3.Callback;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.example.age.data.json.JsonValues;
+
+final class JsonApiClientImpl implements JsonApiClient {
+
+    /** Creates a builder for a JSON API request, using the specified {@link OkHttpClient}. */
+    public static UrlStageRequestBuilder requestBuilder(OkHttpClient client) {
+        return new RequestBuilder(client);
+    }
+
+    // static class
+    private JsonApiClientImpl() {}
+
+    /** Builder for a JSON API request. */
+    private static final class RequestBuilder
+            implements UrlStageRequestBuilder,
+                    HeadersOrFinalStageRequestBuilder,
+                    HeadersOrBodyOrFinalStageRequestBuilder {
+
+        private static final MediaType JSON_CONTENT_TYPE = MediaType.get("application/json");
+        private static final RequestBody EMPTY_BODY = RequestBody.create(new byte[0]);
+
+        private final OkHttpClient client;
+
+        private RequestBuilderStage stage = RequestBuilderStage.URL;
+        private String method = null;
+        private String url = null;
+        private Map<String, String> headers = Map.of();
+        private RequestBody body = EMPTY_BODY;
+
+        @Override
+        public RequestBuilder get(String url) {
+            checkAndAdvanceStage(RequestBuilderStage.URL, RequestBuilderStage.HEADERS);
+            method = "GET";
+            this.url = url;
+            return this;
+        }
+
+        @Override
+        public RequestBuilder post(String url) {
+            checkAndAdvanceStage(RequestBuilderStage.URL, RequestBuilderStage.HEADERS);
+            method = "POST";
+            this.url = url;
+            return this;
+        }
+
+        @Override
+        public RequestBuilder headers(Map<String, String> headers) {
+            checkAndAdvanceStage(RequestBuilderStage.HEADERS, RequestBuilderStage.BODY);
+            this.headers = Map.copyOf(headers);
+            return this;
+        }
+
+        @Override
+        public RequestBuilder body(Object requestValue) {
+            checkAndAdvanceStage(RequestBuilderStage.BODY, RequestBuilderStage.FINAL);
+            byte[] rawRequestValue = JsonValues.serialize(requestValue);
+            body = RequestBody.create(rawRequestValue, JSON_CONTENT_TYPE);
+            return this;
+        }
+
+        @Override
+        public Response execute() throws IOException {
+            checkAndAdvanceStage(RequestBuilderStage.FINAL, RequestBuilderStage.BUILT);
+            Request request = build();
+            return client.newCall(request).execute();
+        }
+
+        @Override
+        public void enqueue(Callback callback) {
+            checkAndAdvanceStage(RequestBuilderStage.FINAL, RequestBuilderStage.BUILT);
+            Request request = build();
+            client.newCall(request).enqueue(callback);
+        }
+
+        /** Builds the {@link Request}. */
+        private Request build() {
+            Request.Builder requestBuilder = new Request.Builder().url(url);
+            headers.forEach((name, value) -> requestBuilder.header(name, value));
+            if (method.equals("GET")) {
+                requestBuilder.get();
+            } else {
+                requestBuilder.method(method, body);
+            }
+            return requestBuilder.build();
+        }
+
+        /** Checks the current builder stage, and also advances the builder stage. */
+        private void checkAndAdvanceStage(RequestBuilderStage expected, RequestBuilderStage next) {
+            if (stage.compareTo(expected) > 0) {
+                throw new IllegalStateException("stage already completed");
+            }
+
+            stage = next;
+        }
+
+        private RequestBuilder(OkHttpClient client) {
+            this.client = client;
+        }
+    }
+
+    /** Stages for the {@link RequestBuilder}. */
+    private enum RequestBuilderStage {
+        URL,
+        HEADERS,
+        BODY,
+        FINAL,
+        BUILT,
+    }
+}

--- a/infra/client/src/test/java/org/example/age/client/infra/JsonApiClientTest.java
+++ b/infra/client/src/test/java/org/example/age/client/infra/JsonApiClientTest.java
@@ -122,20 +122,11 @@ public final class JsonApiClientTest {
     }
 
     @Test
-    public void error_MethodAndUrlNotSet() {
-        JsonApiClient.RequestBuilder requestBuilder = JsonApiClient.requestBuilder(client);
-        assertThatThrownBy(requestBuilder::execute)
+    public void error_StageCompleted() {
+        JsonApiClient.UrlStageRequestBuilder requestBuilder = JsonApiClient.requestBuilder(client);
+        requestBuilder.get(mockServerUrl);
+        assertThatThrownBy(() -> requestBuilder.get(mockServerUrl))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("method and URL are not set");
-    }
-
-    @Test
-    public void error_BodySetForGetRequest() {
-        JsonApiClient.RequestBuilder requestBuilder = JsonApiClient.requestBuilder(client)
-                .get(mockServerUrl)
-                .body("\"test\"".getBytes(StandardCharsets.UTF_8));
-        assertThatThrownBy(requestBuilder::execute)
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("body is set for GET request");
+                .hasMessage("stage already completed");
     }
 }

--- a/infra/service/src/main/java/org/example/age/service/infra/client/RequestDispatcher.java
+++ b/infra/service/src/main/java/org/example/age/service/infra/client/RequestDispatcher.java
@@ -14,22 +14,31 @@ import org.example.age.api.base.Sender;
 public interface RequestDispatcher {
 
     /** Creates a builder for a request whose response is only a status code. */
-    RequestBuilder<Integer> requestBuilder(Dispatcher dispatcher);
+    UrlStageRequestBuilder<Integer> requestBuilder(Dispatcher dispatcher);
 
     /** Creates a builder for a request whose response is a value (or an error status code). */
-    <V> RequestBuilder<HttpOptional<V>> requestBuilder(Dispatcher dispatcher, TypeReference<V> responseValueTypeRef);
+    <V> UrlStageRequestBuilder<HttpOptional<V>> requestBuilder(
+            Dispatcher dispatcher, TypeReference<V> responseValueTypeRef);
 
-    /** Builder for a request to the backend server. */
-    interface RequestBuilder<V> {
+    /** Builder for a request that can set the method and the URL together. */
+    interface UrlStageRequestBuilder<V> {
 
         /** Uses a GET request at the specified URL. */
-        RequestBuilder<V> get(String url);
+        FinalStageRequestBuilder<V> get(String url);
 
         /** Uses a POST request at the specified URL. */
-        RequestBuilder<V> post(String url);
+        BodyOrFinalStageRequestBuilder<V> post(String url);
+    }
+
+    /** Builder for a request that can set the body, or build and dispatch the request. */
+    interface BodyOrFinalStageRequestBuilder<V> extends FinalStageRequestBuilder<V> {
 
         /** Sets the body. */
-        RequestBuilder<V> body(Object requestValue);
+        FinalStageRequestBuilder<V> body(Object requestValue);
+    }
+
+    /** Builder for a request that can build and dispatch the request. */
+    interface FinalStageRequestBuilder<V> {
 
         /** Dispatches the request using a callback. */
         <S extends Sender> void dispatch(S sender, ApiHandler.OneArg<S, V> callback);

--- a/testing/src/testFixtures/java/org/example/age/testing/client/TestClientImpl.java
+++ b/testing/src/testFixtures/java/org/example/age/testing/client/TestClientImpl.java
@@ -1,0 +1,127 @@
+package org.example.age.testing.client;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.io.IOException;
+import java.util.Map;
+import okhttp3.MediaType;
+import okhttp3.Response;
+import org.example.age.api.base.HttpOptional;
+import org.example.age.client.infra.JsonApiClient;
+import org.example.age.client.infra.ResponseConverter;
+import org.example.age.data.json.JsonValues;
+
+final class TestClientImpl implements TestClient {
+
+    /** Creates a builder for a JSON API request whose response is only a status code. */
+    public static UrlStageRequestBuilder<Integer> requestBuilder() {
+        JsonApiClient.UrlStageRequestBuilder requestBuilder = JsonApiClient.requestBuilder(TestOkHttpClient.get());
+        AdaptedExecutor<Integer> executor = new AdaptedExecutor<>(Response::code);
+        return new UrlStageRequestBuilderImpl<>(requestBuilder, executor);
+    }
+
+    /** Creates a builder for a JSON API request whose response is a value (or an error status code). */
+    public static <V> UrlStageRequestBuilder<HttpOptional<V>> requestBuilder(TypeReference<V> responseValueTypeRef) {
+        JsonApiClient.UrlStageRequestBuilder requestBuilder = JsonApiClient.requestBuilder(TestOkHttpClient.get());
+        ResponseConverter<HttpOptional<V>> responseConverter = new JsonValueResponseConverter<>(responseValueTypeRef);
+        AdaptedExecutor<HttpOptional<V>> executor = new AdaptedExecutor<>(responseConverter);
+        return new UrlStageRequestBuilderImpl<>(requestBuilder, executor);
+    }
+
+    // static class
+    private TestClientImpl() {}
+
+    /** Internal {@link UrlStageRequestBuilder} implementation. */
+    private record UrlStageRequestBuilderImpl<V>(
+            JsonApiClient.UrlStageRequestBuilder requestBuilder, AdaptedExecutor<V> executor)
+            implements TestClient.UrlStageRequestBuilder<V> {
+
+        @Override
+        public HeadersOrFinalStageRequestBuilder<V> get(String url) {
+            return new HeadersOrFinalStageRequestBuilderImpl<>(requestBuilder.get(url), executor);
+        }
+
+        @Override
+        public HeadersOrBodyOrFinalStageRequestBuilder<V> post(String url) {
+            return new HeadersOrBodyOrFinalStageRequestBuilderImpl<>(requestBuilder.post(url), executor);
+        }
+    }
+
+    /**
+     * Internal {@link HeadersOrFinalStageRequestBuilder} (and {@link FinalStageRequestBuilder}) implementation.
+     *
+     * <p>Also implements the {@link UrlStageRequestBuilder#get} branch.</p>
+     */
+    private record HeadersOrFinalStageRequestBuilderImpl<V>(
+            JsonApiClient.HeadersOrFinalStageRequestBuilder requestBuilder, AdaptedExecutor<V> executor)
+            implements HeadersOrFinalStageRequestBuilder<V> {
+
+        @Override
+        public FinalStageRequestBuilder<V> headers(Map<String, String> headers) {
+            requestBuilder.headers(headers);
+            return this;
+        }
+
+        @Override
+        public V execute() throws IOException {
+            return executor.execute(requestBuilder);
+        }
+    }
+
+    /**
+     * Internal {@link HeadersOrBodyOrFinalStageRequestBuilder}
+     * (and {@link FinalStageRequestBuilder} and {@link FinalStageRequestBuilder}) implementation.
+     *
+     * <p>Also implements the {@link UrlStageRequestBuilder#post} branch.</p>
+     */
+    private record HeadersOrBodyOrFinalStageRequestBuilderImpl<V>(
+            JsonApiClient.HeadersOrBodyOrFinalStageRequestBuilder requestBuilder, AdaptedExecutor<V> executor)
+            implements HeadersOrBodyOrFinalStageRequestBuilder<V> {
+
+        @Override
+        public BodyOrFinalStageRequestBuilder<V> headers(Map<String, String> headers) {
+            requestBuilder.headers(headers);
+            return this;
+        }
+
+        @Override
+        public FinalStageRequestBuilder<V> body(Object requestValue) {
+            requestBuilder.body(requestValue);
+            return this;
+        }
+
+        @Override
+        public V execute() throws IOException {
+            return executor.execute(requestBuilder);
+        }
+    }
+
+    /**
+     * Adapts {@link FinalStageRequestBuilder#execute()} to {@link JsonApiClient.FinalStageRequestBuilder#execute()}.
+     */
+    private record AdaptedExecutor<V>(ResponseConverter<V> responseConverter) {
+
+        public V execute(JsonApiClient.FinalStageRequestBuilder requestBuilder) throws IOException {
+            Response response = requestBuilder.execute();
+            return responseConverter.convert(response);
+        }
+    }
+
+    /** Reads the response body and deserializes it from JSON, or returns an error status code. */
+    private record JsonValueResponseConverter<V>(TypeReference<V> valueTypeRef)
+            implements ResponseConverter<HttpOptional<V>> {
+
+        private static final MediaType JSON_CONTENT_TYPE = MediaType.get("application/json");
+
+        @Override
+        public HttpOptional<V> convert(Response response) throws IOException {
+            if (!response.isSuccessful()) {
+                return HttpOptional.empty(response.code());
+            }
+
+            TestOkHttpClient.assertContentType(response, JSON_CONTENT_TYPE);
+            byte[] rawValue = response.body().bytes();
+            V value = JsonValues.deserialize(rawValue, valueTypeRef);
+            return HttpOptional.of(value);
+        }
+    }
+}


### PR DESCRIPTION
When implementing staged builders, it helps to put the interface and implementation in separate classes. As expected, nothing changes in the consumers of these clients, as they were advancing through the stages correctly.