### PR TITLE
demo AccountIdExtractor

### DIFF
--- a/module/extractor/demo/build.gradle.kts
+++ b/module/extractor/demo/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    id("org.example.age.java-conventions")
+    `java-library`
+}
+
+dependencies {
+    // main
+    annotationProcessor("com.google.dagger:dagger-compiler")
+
+    api(project(":core:api:extractors:common"))
+    api("com.google.dagger:dagger")
+    api("javax.inject:javax.inject")
+
+    implementation(project(":base:api:base"))
+    implementation("io.undertow:undertow-core")
+
+    // test
+    testAnnotationProcessor("com.google.dagger:dagger-compiler")
+
+    testImplementation(project(":base:api:base"))
+    testImplementation(project(":core:api:extractors:common"))
+    testImplementation(testFixtures(project(":base:api:base")))
+    testImplementation("com.google.dagger:dagger")
+    testImplementation("io.undertow:undertow-core")
+    testImplementation("javax.inject:javax.inject")
+    testImplementation("org.mockito:mockito-core")
+}

--- a/module/extractor/demo/src/main/java/org/example/age/module/extractor/demo/common/DemoAccountIdExtractor.java
+++ b/module/extractor/demo/src/main/java/org/example/age/module/extractor/demo/common/DemoAccountIdExtractor.java
@@ -1,0 +1,24 @@
+package org.example.age.module.extractor.demo.common;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.StatusCodes;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.example.age.api.base.HttpOptional;
+import org.example.age.api.extractor.common.AccountIdExtractor;
+
+/** Extracts an account ID from the custom {@code Account-Id} header, or sends a 401 error. */
+@Singleton
+final class DemoAccountIdExtractor implements AccountIdExtractor {
+
+    @Inject
+    public DemoAccountIdExtractor() {}
+
+    @Override
+    public HttpOptional<String> tryExtract(HttpServerExchange exchange) {
+        Optional<String> maybeAccountId =
+                Optional.ofNullable(exchange.getRequestHeaders().getFirst("Account-Id"));
+        return HttpOptional.fromOptional(maybeAccountId, StatusCodes.UNAUTHORIZED);
+    }
+}

--- a/module/extractor/demo/src/main/java/org/example/age/module/extractor/demo/common/DemoAccountIdExtractorModule.java
+++ b/module/extractor/demo/src/main/java/org/example/age/module/extractor/demo/common/DemoAccountIdExtractorModule.java
@@ -1,0 +1,16 @@
+package org.example.age.module.extractor.demo.common;
+
+import dagger.Binds;
+import dagger.Module;
+import org.example.age.api.extractor.common.AccountIdExtractor;
+
+/**
+ * Dagger module that publishes a binding for {@link AccountIdExtractor},
+ * which reads the custom {@code Account-Id} header, or returns a 401 error.
+ */
+@Module
+public interface DemoAccountIdExtractorModule {
+
+    @Binds
+    AccountIdExtractor bindAccountIdExtractor(DemoAccountIdExtractor impl);
+}

--- a/module/extractor/demo/src/test/java/org/example/age/module/extractor/demo/common/DemoAccountIdExtractorTest.java
+++ b/module/extractor/demo/src/test/java/org/example/age/module/extractor/demo/common/DemoAccountIdExtractorTest.java
@@ -1,0 +1,62 @@
+package org.example.age.module.extractor.demo.common;
+
+import static org.example.age.testing.api.HttpOptionalAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dagger.Component;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderMap;
+import io.undertow.util.HttpString;
+import java.util.Optional;
+import javax.inject.Singleton;
+import org.example.age.api.base.HttpOptional;
+import org.example.age.api.extractor.common.AccountIdExtractor;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public final class DemoAccountIdExtractorTest {
+
+    private static AccountIdExtractor accountIdExtractor;
+
+    @BeforeAll
+    public static void createAccountIdExtractor() {
+        accountIdExtractor = TestComponent.createAccountIdExtractor();
+    }
+
+    @Test
+    public void extract() {
+        HttpServerExchange exchange = createStubExchange(Optional.of("username"));
+        HttpOptional<String> maybeAccountId = accountIdExtractor.tryExtract(exchange);
+        assertThat(maybeAccountId).hasValue("username");
+    }
+
+    @Test
+    public void extractFailed() {
+        HttpServerExchange exchange = createStubExchange(Optional.empty());
+        HttpOptional<String> maybeAccountId = accountIdExtractor.tryExtract(exchange);
+        assertThat(maybeAccountId).isEmptyWithErrorCode(401);
+    }
+
+    private static HttpServerExchange createStubExchange(Optional<String> maybeAccountId) {
+        HeaderMap requestHeaderMap = new HeaderMap();
+        maybeAccountId.ifPresent(userAgent -> requestHeaderMap.put(HttpString.tryFromString("Account-Id"), userAgent));
+
+        HttpServerExchange exchange = mock(HttpServerExchange.class);
+        when(exchange.getRequestHeaders()).thenReturn(requestHeaderMap);
+        return exchange;
+    }
+
+    /** Dagger component that provides an {@link AccountIdExtractor}. */
+    @Component(modules = DemoAccountIdExtractorModule.class)
+    @Singleton
+    interface TestComponent {
+
+        static AccountIdExtractor createAccountIdExtractor() {
+            TestComponent component = DaggerDemoAccountIdExtractorTest_TestComponent.create();
+            return component.accountIdExtractor();
+        }
+
+        AccountIdExtractor accountIdExtractor();
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,6 +35,7 @@ include(
         "core:integration-test",
 
         "module:extractor:builtin:common",
+        "module:extractor:demo:common",
         "module:extractor:test:common",
         "module:store:inmemory:common",
         "module:service:test:common",


### PR DESCRIPTION
more or less a copy of the `test` extractor, but...

- we need an extractor in `main`, not `testFixtures`
- this extractor may go away when a UI is added to the demo
- the `test` extractor will not go away; it's used in integration tests