### PR TITLE
tweak Dagger bindings for resource module

### DIFF
--- a/module/service/resource/src/main/java/org/example/age/module/config/resource/ResourceAvsConfigModule.java
+++ b/module/service/resource/src/main/java/org/example/age/module/config/resource/ResourceAvsConfigModule.java
@@ -17,7 +17,7 @@ import org.example.age.service.config.RefreshableRegisteredSiteConfigProvider;
  * <p>Depends on an unbound...</p>
  * <ul>
  *     <li><code>@Named("resources") {@link Class}&lt;?&gt;</code></li>
- *     <li><code>@Named("resourcesAvs") {@link Path}</code></li>
+ *     <li><code>@Named("resources") {@link Path}</code></li>
  * </ul>
  */
 @Module(includes = ResourceLoaderModule.class)

--- a/module/service/resource/src/main/java/org/example/age/module/config/resource/ResourceAvsConfigProvider.java
+++ b/module/service/resource/src/main/java/org/example/age/module/config/resource/ResourceAvsConfigProvider.java
@@ -15,8 +15,8 @@ import org.example.age.service.config.RefreshableAvsConfigProvider;
 final class ResourceAvsConfigProvider extends JsonResourceProvider<AvsConfig> implements RefreshableAvsConfigProvider {
 
     @Inject
-    public ResourceAvsConfigProvider(ResourceLoader resourceLoader, @Named("resourcesAvs") Path avsPath) {
-        super(resourceLoader, avsPath.resolve("config/config.json"), new TypeReference<>() {});
+    public ResourceAvsConfigProvider(ResourceLoader resourceLoader, @Named("resources") Path rootPath) {
+        super(resourceLoader, rootPath.resolve("config/config.json"), new TypeReference<>() {});
     }
 
     @Override

--- a/module/service/resource/src/main/java/org/example/age/module/config/resource/ResourceRegisteredSiteConfigProvider.java
+++ b/module/service/resource/src/main/java/org/example/age/module/config/resource/ResourceRegisteredSiteConfigProvider.java
@@ -18,8 +18,8 @@ final class ResourceRegisteredSiteConfigProvider extends JsonResourceProvider<Ma
         implements RefreshableRegisteredSiteConfigProvider {
 
     @Inject
-    public ResourceRegisteredSiteConfigProvider(ResourceLoader resourceLoader, @Named("resourcesAvs") Path avsPath) {
-        super(resourceLoader, avsPath.resolve("config/siteConfigs.json"), new TypeReference<>() {});
+    public ResourceRegisteredSiteConfigProvider(ResourceLoader resourceLoader, @Named("resources") Path rootPath) {
+        super(resourceLoader, rootPath.resolve("config/siteConfigs.json"), new TypeReference<>() {});
     }
 
     @Override

--- a/module/service/resource/src/main/java/org/example/age/module/config/resource/ResourceSiteConfigModule.java
+++ b/module/service/resource/src/main/java/org/example/age/module/config/resource/ResourceSiteConfigModule.java
@@ -3,6 +3,7 @@ package org.example.age.module.config.resource;
 import dagger.Binds;
 import dagger.Module;
 import java.nio.file.Path;
+import org.example.age.module.internal.resource.ResourceLoaderModule;
 import org.example.age.service.config.RefreshableSiteConfigProvider;
 
 /**
@@ -11,10 +12,10 @@ import org.example.age.service.config.RefreshableSiteConfigProvider;
  * <p>Depends on an unbound...</p>
  * <ul>
  *     <li><code>@Named("resources") {@link Class}&lt;?&gt;</code></li>
- *     <li><code>@Named("resourcesSite") {@link Path}</code></li>
+ *     <li><code>@Named("resources") {@link Path}</code></li>
  * </ul>
  */
-@Module
+@Module(includes = ResourceLoaderModule.class)
 public interface ResourceSiteConfigModule {
 
     @Binds

--- a/module/service/resource/src/main/java/org/example/age/module/config/resource/ResourceSiteConfigProvider.java
+++ b/module/service/resource/src/main/java/org/example/age/module/config/resource/ResourceSiteConfigProvider.java
@@ -16,8 +16,8 @@ final class ResourceSiteConfigProvider extends JsonResourceProvider<SiteConfig>
         implements RefreshableSiteConfigProvider {
 
     @Inject
-    public ResourceSiteConfigProvider(ResourceLoader resourceLoader, @Named("resourcesSite") Path sitePath) {
-        super(resourceLoader, sitePath.resolve("config/config.json"), new TypeReference<>() {});
+    public ResourceSiteConfigProvider(ResourceLoader resourceLoader, @Named("resources") Path rootPath) {
+        super(resourceLoader, rootPath.resolve("config/config.json"), new TypeReference<>() {});
     }
 
     @Override

--- a/module/service/resource/src/main/java/org/example/age/module/store/resource/ResourceAvsVerificationStoreInitializer.java
+++ b/module/service/resource/src/main/java/org/example/age/module/store/resource/ResourceAvsVerificationStoreInitializer.java
@@ -18,8 +18,8 @@ final class ResourceAvsVerificationStoreInitializer extends JsonResourceProvider
         implements VerificationStoreInitializer {
 
     @Inject
-    public ResourceAvsVerificationStoreInitializer(ResourceLoader resourceLoader, @Named("resourcesAvs") Path avsPath) {
-        super(resourceLoader, avsPath.resolve("store/accounts.json"), new TypeReference<>() {});
+    public ResourceAvsVerificationStoreInitializer(ResourceLoader resourceLoader, @Named("resources") Path rootPath) {
+        super(resourceLoader, rootPath.resolve("store/accounts.json"), new TypeReference<>() {});
     }
 
     @Override

--- a/module/service/resource/src/main/java/org/example/age/module/store/resource/ResourceAvsVerificationStoreModule.java
+++ b/module/service/resource/src/main/java/org/example/age/module/store/resource/ResourceAvsVerificationStoreModule.java
@@ -3,6 +3,7 @@ package org.example.age.module.store.resource;
 import dagger.Binds;
 import dagger.Module;
 import java.nio.file.Path;
+import org.example.age.module.internal.resource.ResourceLoaderModule;
 import org.example.age.module.store.inmemory.InMemoryVerificationStoreModule;
 import org.example.age.module.store.inmemory.VerificationStoreInitializer;
 import org.example.age.service.store.VerificationStore;
@@ -14,10 +15,10 @@ import org.example.age.service.store.VerificationStore;
  * <p>Depends on an unbound...</p>
  * <ul>
  *     <li><code>@Named("resources") {@link Class}&lt;?&gt;</code></li>
- *     <li><code>@Named("resourcesAvs") {@link Path}</code></li>
+ *     <li><code>@Named("resources") {@link Path}</code></li>
  * </ul>
  */
-@Module(includes = InMemoryVerificationStoreModule.class)
+@Module(includes = {InMemoryVerificationStoreModule.class, ResourceLoaderModule.class})
 public interface ResourceAvsVerificationStoreModule {
 
     @Binds

--- a/module/service/resource/src/test/java/org/example/age/module/config/resource/ResourceAvsConfigTest.java
+++ b/module/service/resource/src/test/java/org/example/age/module/config/resource/ResourceAvsConfigTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dagger.Component;
 import javax.inject.Singleton;
-import org.example.age.module.internal.resource.TestResourceModule;
+import org.example.age.module.internal.resource.TestAvsResourceModule;
 import org.example.age.service.config.AvsConfig;
 import org.example.age.service.config.RefreshableAvsConfigProvider;
 import org.junit.jupiter.api.Test;
@@ -19,7 +19,7 @@ final class ResourceAvsConfigTest {
     }
 
     /** Dagger component that provides a {@link RefreshableAvsConfigProvider}. */
-    @Component(modules = {ResourceAvsConfigModule.class, TestResourceModule.class})
+    @Component(modules = {ResourceAvsConfigModule.class, TestAvsResourceModule.class})
     @Singleton
     interface TestComponent {
 

--- a/module/service/resource/src/test/java/org/example/age/module/config/resource/ResourceRegisteredSiteConfigTest.java
+++ b/module/service/resource/src/test/java/org/example/age/module/config/resource/ResourceRegisteredSiteConfigTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import dagger.Component;
 import java.util.Optional;
 import javax.inject.Singleton;
-import org.example.age.module.internal.resource.TestResourceModule;
+import org.example.age.module.internal.resource.TestAvsResourceModule;
 import org.example.age.service.config.RefreshableRegisteredSiteConfigProvider;
 import org.example.age.service.config.RegisteredSiteConfig;
 import org.junit.jupiter.api.BeforeAll;
@@ -33,7 +33,7 @@ public final class ResourceRegisteredSiteConfigTest {
     }
 
     /** Dagger component that provides a {@link RefreshableRegisteredSiteConfigProvider}. */
-    @Component(modules = {ResourceAvsConfigModule.class, TestResourceModule.class})
+    @Component(modules = {ResourceAvsConfigModule.class, TestAvsResourceModule.class})
     @Singleton
     interface TestComponent {
 

--- a/module/service/resource/src/test/java/org/example/age/module/config/resource/ResourceSiteConfigTest.java
+++ b/module/service/resource/src/test/java/org/example/age/module/config/resource/ResourceSiteConfigTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dagger.Component;
 import javax.inject.Singleton;
-import org.example.age.module.internal.resource.TestResourceModule;
+import org.example.age.module.internal.resource.TestSiteResourceModule;
 import org.example.age.service.config.RefreshableSiteConfigProvider;
 import org.example.age.service.config.SiteConfig;
 import org.junit.jupiter.api.Test;
@@ -19,7 +19,7 @@ public final class ResourceSiteConfigTest {
     }
 
     /** Dagger component that provides a {@link RefreshableSiteConfigProvider}. */
-    @Component(modules = {ResourceSiteConfigModule.class, TestResourceModule.class})
+    @Component(modules = {ResourceSiteConfigModule.class, TestSiteResourceModule.class})
     @Singleton
     interface TestComponent {
 

--- a/module/service/resource/src/test/java/org/example/age/module/internal/resource/ResourceLoaderTest.java
+++ b/module/service/resource/src/test/java/org/example/age/module/internal/resource/ResourceLoaderTest.java
@@ -33,7 +33,7 @@ public final class ResourceLoaderTest {
     }
 
     /** Dagger component that provides a {@link ResourceLoader}. */
-    @Component(modules = {ResourceLoaderModule.class, TestResourceModule.class})
+    @Component(modules = {ResourceLoaderModule.class, TestSiteResourceModule.class})
     @Singleton
     interface TestComponent {
 

--- a/module/service/resource/src/test/java/org/example/age/module/internal/resource/TestAvsResourceModule.java
+++ b/module/service/resource/src/test/java/org/example/age/module/internal/resource/TestAvsResourceModule.java
@@ -1,0 +1,32 @@
+package org.example.age.module.internal.resource;
+
+import dagger.Module;
+import dagger.Provides;
+import java.nio.file.Path;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+/**
+ * Dagger module that publishes bindings for...
+ * <ul>
+ *     <li><code>@Named("resources") {@link Class}&lt;?&gt;</code></li>
+ *     <li><code>@Named("resources") {@link Path}</code></li>
+ * </ul>
+ */
+@Module
+public interface TestAvsResourceModule {
+
+    @Provides
+    @Named("resources")
+    @Singleton
+    static Class<?> provideResourcesClass() {
+        return TestSiteResourceModule.class;
+    }
+
+    @Provides
+    @Named("resources")
+    @Singleton
+    static Path provideResourcesSitePath() {
+        return Path.of("AVS");
+    }
+}

--- a/module/service/resource/src/test/java/org/example/age/module/internal/resource/TestSiteResourceModule.java
+++ b/module/service/resource/src/test/java/org/example/age/module/internal/resource/TestSiteResourceModule.java
@@ -10,31 +10,23 @@ import javax.inject.Singleton;
  * Dagger module that publishes bindings for...
  * <ul>
  *     <li><code>@Named("resources") {@link Class}&lt;?&gt;</code></li>
- *     <li><code>@Named("resourcesSite") {@link Path}</code></li>
- *     <li><code>@Named("resourcesAvs") {@link Path}</code></li>
+ *     <li><code>@Named("resources") {@link Path}</code></li>
  * </ul>
  */
-@Module(includes = ResourceLoaderModule.class)
-public interface TestResourceModule {
+@Module
+public interface TestSiteResourceModule {
 
     @Provides
     @Named("resources")
     @Singleton
     static Class<?> provideResourcesClass() {
-        return TestResourceModule.class;
+        return TestSiteResourceModule.class;
     }
 
     @Provides
-    @Named("resourcesSite")
+    @Named("resources")
     @Singleton
     static Path provideResourcesSitePath() {
         return Path.of("Site");
-    }
-
-    @Provides
-    @Named("resourcesAvs")
-    @Singleton
-    static Path provideResourcesAvsPath() {
-        return Path.of("AVS");
     }
 }

--- a/module/service/resource/src/test/java/org/example/age/module/location/resource/ResourceLocationTest.java
+++ b/module/service/resource/src/test/java/org/example/age/module/location/resource/ResourceLocationTest.java
@@ -6,7 +6,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import dagger.Component;
 import java.util.NoSuchElementException;
 import javax.inject.Singleton;
-import org.example.age.module.internal.resource.TestResourceModule;
+import org.example.age.module.internal.resource.TestAvsResourceModule;
+import org.example.age.module.internal.resource.TestSiteResourceModule;
 import org.example.age.service.location.Location;
 import org.example.age.service.location.RefreshableAvsLocationProvider;
 import org.example.age.service.location.RefreshableSiteLocationProvider;
@@ -44,7 +45,7 @@ public final class ResourceLocationTest {
     }
 
     /** Dagger component that provides a {@link RefreshableAvsLocationProvider}. */
-    @Component(modules = {ResourceAvsLocationModule.class, TestResourceModule.class})
+    @Component(modules = {ResourceAvsLocationModule.class, TestSiteResourceModule.class})
     @Singleton
     interface TestSiteComponent {
 
@@ -57,7 +58,7 @@ public final class ResourceLocationTest {
     }
 
     /** Dagger component that provides a {@link RefreshableSiteLocationProvider}. */
-    @Component(modules = {ResourceSiteLocationModule.class, TestResourceModule.class})
+    @Component(modules = {ResourceSiteLocationModule.class, TestAvsResourceModule.class})
     @Singleton
     interface TestAvsComponent {
 

--- a/module/service/resource/src/test/java/org/example/age/module/store/resource/ResourceAvsVerificationStoreTest.java
+++ b/module/service/resource/src/test/java/org/example/age/module/store/resource/ResourceAvsVerificationStoreTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import dagger.Component;
 import javax.inject.Singleton;
 import org.example.age.api.def.VerificationStatus;
-import org.example.age.module.internal.resource.TestResourceModule;
+import org.example.age.module.internal.resource.TestAvsResourceModule;
 import org.example.age.service.store.VerificationStore;
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +18,7 @@ public final class ResourceAvsVerificationStoreTest {
     }
 
     /** Dagger component that provides a {@link VerificationStore}. */
-    @Component(modules = {ResourceAvsVerificationStoreModule.class, TestResourceModule.class})
+    @Component(modules = {ResourceAvsVerificationStoreModule.class, TestAvsResourceModule.class})
     @Singleton
     interface TestComponent {
 


### PR DESCRIPTION
- always use `@Named("resources") Path`
    - create two separate test modules that bind different values
- module fixes