### PR TITLE
redesigned API client

### DIFF
--- a/infra/client/build.gradle.kts
+++ b/infra/client/build.gradle.kts
@@ -5,11 +5,17 @@ plugins {
 
 dependencies {
     // main
+    api(project(":base:api:base"))
+    api("com.fasterxml.jackson.core:jackson-core")
     api("com.squareup.okhttp3:okhttp")
 
     implementation(project(":base:data:json"))
 
     // test
+    testImplementation(project(":base:api:base"))
+    testImplementation(testFixtures(project(":base:api:base")))
+    testImplementation("com.fasterxml.jackson.core:jackson-core")
     testImplementation("com.squareup.okhttp3:mockwebserver")
+    testImplementation("com.squareup.okhttp3:okhttp")
     testImplementation("com.squareup.okio:okio-jvm")
 }

--- a/infra/client/src/main/java/org/example/age/client/infra/ApiClient.java
+++ b/infra/client/src/main/java/org/example/age/client/infra/ApiClient.java
@@ -1,0 +1,45 @@
+package org.example.age.client.infra;
+
+import java.util.Map;
+
+/** HTTP client for an API. The request builder includes a post-build stage that can make the request. */
+public interface ApiClient {
+
+    /** Builder for an API request that can set the method and the URL together. */
+    interface UrlStageRequestBuilder<S> {
+
+        /** Uses a GET request at the specified URL. */
+        HeadersOrFinalStageRequestBuilder<S> get(String url);
+
+        /** Uses a POST request at the specified URL. */
+        HeadersOrBodyOrFinalStageRequestBuilder<S> post(String url);
+    }
+
+    /** Builder for an API request that can set the headers, or build the request. */
+    interface HeadersOrFinalStageRequestBuilder<S> extends FinalStageRequestBuilder<S> {
+
+        /** Sets the headers. */
+        FinalStageRequestBuilder<S> headers(Map<String, String> headers);
+    }
+
+    /** Builder for an API request that can set the headers, set the body, or build the request. */
+    interface HeadersOrBodyOrFinalStageRequestBuilder<S> extends BodyOrFinalStageRequestBuilder<S> {
+
+        /** Sets the headers. */
+        BodyOrFinalStageRequestBuilder<S> headers(Map<String, String> headers);
+    }
+
+    /** Builder for an API request that can set the body, or build the request. */
+    interface BodyOrFinalStageRequestBuilder<S> extends FinalStageRequestBuilder<S> {
+
+        /** Sets the body. */
+        FinalStageRequestBuilder<S> body(Object requestValue);
+    }
+
+    /** Builder for an API request that can build the request. */
+    interface FinalStageRequestBuilder<S> {
+
+        /** Builds the request, returning a post-build stage that can make the request. */
+        S build();
+    }
+}

--- a/infra/client/src/main/java/org/example/age/client/infra/OkHttpJsonApiClient.java
+++ b/infra/client/src/main/java/org/example/age/client/infra/OkHttpJsonApiClient.java
@@ -1,0 +1,185 @@
+package org.example.age.client.infra;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.io.IOException;
+import java.util.Map;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.example.age.api.base.HttpOptional;
+import org.example.age.data.json.JsonValues;
+
+/**
+ * JSON {@link ApiClient} that is internally backed by an {@link OkHttpClient}.
+ *
+ * <p>Implementations will bind the type parameter {@code S}
+ * and provide {@code requestBuilder()} and <code>requestBuilder({@link TypeReference}&lt;V&gt;)</code> methods.</p>
+ */
+public abstract class OkHttpJsonApiClient implements ApiClient {
+
+    // If a generic method has multiple type parameters (e.g., S and V),
+    // an @Override of that method cannot bind some type parameters (e.g., bind S but not V).
+    // This limitation of Java influences the design of this class.
+    // (Also, S will depend on V in implementations. As a result, S also cannot be defined in the class declaration.)
+
+    /** Creates a builder for a JSON API request whose response is only a status code. */
+    protected final <S> UrlStageRequestBuilder<S> requestBuilder(BuiltStageFactory<S, Integer> builtStageFactory) {
+        return new RequestBuilder<>(builtStageFactory, Response::code);
+    }
+
+    /** Creates a builder for a JSON API request whose response is a JSON value (or an error status code). */
+    protected final <S, V> UrlStageRequestBuilder<S> requestBuilder(
+            BuiltStageFactory<S, HttpOptional<V>> builtStageFactory, TypeReference<V> responseValueTypeRef) {
+        ResponseConverter<HttpOptional<V>> responseConverter = new JsonValueResponseConverter<>(responseValueTypeRef);
+        return new RequestBuilder<>(builtStageFactory, responseConverter);
+    }
+
+    /** Creates the built stage from the built {@link Request} and the {@link ResponseConverter}. */
+    @FunctionalInterface
+    protected interface BuiltStageFactory<S, V> {
+
+        S create(Request request, ResponseConverter<V> responseConverter);
+    }
+
+    /** Converts the {@link Response} to the value. */
+    @FunctionalInterface
+    protected interface ResponseConverter<V> {
+
+        V convert(Response response) throws IOException;
+    }
+
+    /** Builder for a JSON API request. */
+    private static final class RequestBuilder<S, V>
+            implements UrlStageRequestBuilder<S>,
+                    HeadersOrFinalStageRequestBuilder<S>,
+                    HeadersOrBodyOrFinalStageRequestBuilder<S> {
+
+        private static final MediaType JSON_CONTENT_TYPE = MediaType.get("application/json");
+        private static final RequestBody EMPTY_BODY = RequestBody.create(new byte[0]);
+
+        private final BuiltStageFactory<S, V> builtStageFactory;
+        private final ResponseConverter<V> responseConverter;
+
+        private RequestBuilderStage stage = RequestBuilderStage.URL;
+        private String method = null;
+        private String url = null;
+        private Map<String, String> headers = Map.of();
+        private RequestBody body = EMPTY_BODY;
+
+        @Override
+        public RequestBuilder<S, V> get(String url) {
+            checkAndAdvanceStage(RequestBuilderStage.URL, RequestBuilderStage.HEADERS);
+            method = "GET";
+            this.url = url;
+            return this;
+        }
+
+        @Override
+        public RequestBuilder<S, V> post(String url) {
+            checkAndAdvanceStage(RequestBuilderStage.URL, RequestBuilderStage.HEADERS);
+            method = "POST";
+            this.url = url;
+            return this;
+        }
+
+        @Override
+        public RequestBuilder<S, V> headers(Map<String, String> headers) {
+            checkAndAdvanceStage(RequestBuilderStage.HEADERS, RequestBuilderStage.BODY);
+            this.headers = Map.copyOf(headers);
+            return this;
+        }
+
+        @Override
+        public RequestBuilder<S, V> body(Object requestValue) {
+            checkAndAdvanceStage(RequestBuilderStage.BODY, RequestBuilderStage.FINAL);
+            byte[] rawRequestValue = JsonValues.serialize(requestValue);
+            body = RequestBody.create(rawRequestValue, JSON_CONTENT_TYPE);
+            return this;
+        }
+
+        @Override
+        public S build() {
+            checkAndAdvanceStage(RequestBuilderStage.FINAL, RequestBuilderStage.BUILT);
+            Request request = buildRequest();
+            return builtStageFactory.create(request, responseConverter);
+        }
+
+        /** Builds the {@link Request}. */
+        private Request buildRequest() {
+            Request.Builder requestBuilder = new Request.Builder().url(url);
+            headers.forEach((name, value) -> requestBuilder.header(name, value));
+            if (method.equals("GET")) {
+                requestBuilder.get();
+            } else {
+                requestBuilder.method(method, body);
+            }
+            return requestBuilder.build();
+        }
+
+        /** Checks the current builder stage, and also advances the builder stage. */
+        private void checkAndAdvanceStage(RequestBuilderStage expected, RequestBuilderStage next) {
+            if (stage.compareTo(expected) > 0) {
+                throw new IllegalStateException("stage already completed");
+            }
+
+            stage = next;
+        }
+
+        private RequestBuilder(BuiltStageFactory<S, V> builtStageFactory, ResponseConverter<V> responseConverter) {
+            this.builtStageFactory = builtStageFactory;
+            this.responseConverter = responseConverter;
+        }
+    }
+
+    /** Stages for the {@link RequestBuilder}. */
+    private enum RequestBuilderStage {
+        URL,
+        HEADERS,
+        BODY,
+        FINAL,
+        BUILT,
+    }
+
+    /**
+     * Reads the response body and deserializes it from JSON, or returns an error status code.
+     *
+     * <p>An exception will be thrown if the response is invalid.</p>
+     */
+    private record JsonValueResponseConverter<V>(TypeReference<V> responseValueTypeRef)
+            implements ResponseConverter<HttpOptional<V>> {
+
+        @Override
+        public HttpOptional<V> convert(Response response) throws IOException {
+            if (!response.isSuccessful()) {
+                return HttpOptional.empty(response.code());
+            }
+
+            checkContentType(response);
+            byte[] rawResponseValue = response.body().bytes();
+            V value = JsonValues.deserialize(rawResponseValue, responseValueTypeRef);
+            return HttpOptional.of(value);
+        }
+
+        /** Checks that the {@code Content-Type} is {@code application/json}. */
+        private void checkContentType(Response response) {
+            String rawContentType = response.header("Content-Type");
+            if (rawContentType == null) {
+                throw new IllegalArgumentException("response Content-Type is missing");
+            }
+
+            MediaType contentType = MediaType.parse(rawContentType);
+            if (contentType == null) {
+                String message = String.format("failed to parse response Content-Type: %s", rawContentType);
+                throw new IllegalArgumentException(message);
+            }
+
+            if (!contentType.type().equals("application")
+                    || !contentType.subtype().equals("json")) {
+                String message = String.format("response Content-Type is not application/json: %s", contentType);
+                throw new IllegalArgumentException(message);
+            }
+        }
+    }
+}

--- a/infra/client/src/test/java/org/example/age/client/infra/OkHttpJsonApiClientTest.java
+++ b/infra/client/src/test/java/org/example/age/client/infra/OkHttpJsonApiClientTest.java
@@ -1,0 +1,204 @@
+package org.example.age.client.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.example.age.testing.api.HttpOptionalAssert.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.example.age.api.base.HttpOptional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public final class OkHttpJsonApiClientTest {
+
+    private static TestClient client;
+
+    private MockWebServer mockServer;
+    private String mockServerUrl;
+
+    @BeforeAll
+    public static void createClient() {
+        client = TestClient.create();
+    }
+
+    @BeforeEach
+    public void startMockServer() throws IOException {
+        mockServer = new MockWebServer();
+        mockServer.start();
+        mockServerUrl = mockServer.url("").toString();
+    }
+
+    @AfterEach
+    public void stopMockServer() throws IOException {
+        mockServer.shutdown();
+    }
+
+    @Test
+    public void get_StatusCodeResponse() throws IOException {
+        mockServer.enqueue(new MockResponse());
+        int statusCode = client.requestBuilder().get(mockServerUrl).build().execute();
+        assertThat(statusCode).isEqualTo(200);
+    }
+
+    @Test
+    public void get_JsonValueResponse_Ok() throws IOException {
+        mockServer.enqueue(
+                new MockResponse().setHeader("Content-Type", "application/json").setBody("\"test\""));
+        HttpOptional<String> maybeText = client.requestBuilder(new TypeReference<String>() {})
+                .get(mockServerUrl)
+                .build()
+                .execute();
+        assertThat(maybeText).hasValue("test");
+    }
+
+    @Test
+    public void get_JsonValueResponse_ErrorCode() throws IOException {
+        mockServer.enqueue(new MockResponse().setResponseCode(403));
+        HttpOptional<String> maybeText = client.requestBuilder(new TypeReference<String>() {})
+                .get(mockServerUrl)
+                .build()
+                .execute();
+        assertThat(maybeText).isEmptyWithErrorCode(403);
+    }
+
+    @Test
+    public void get_RequestHeaders() throws Exception {
+        mockServer.enqueue(new MockResponse());
+        int statusCode = client.requestBuilder()
+                .get(mockServerUrl)
+                .headers(Map.of("User-Agent", "agent"))
+                .build()
+                .execute();
+        assertThat(statusCode).isEqualTo(200);
+
+        RecordedRequest recordedRequest = mockServer.takeRequest();
+        assertThat(recordedRequest.getMethod()).isEqualTo("GET");
+        assertThat(recordedRequest.getHeader("User-Agent")).isEqualTo("agent");
+    }
+
+    @Test
+    public void post_NoRequestBody() throws Exception {
+        mockServer.enqueue(new MockResponse());
+        int statusCode = client.requestBuilder().post(mockServerUrl).build().execute();
+        assertThat(statusCode).isEqualTo(200);
+
+        RecordedRequest recordedRequest = mockServer.takeRequest();
+        assertThat(recordedRequest.getMethod()).isEqualTo("POST");
+    }
+
+    @Test
+    public void post_RequestBody() throws Exception {
+        mockServer.enqueue(new MockResponse());
+        int statusCode =
+                client.requestBuilder().post(mockServerUrl).body("test").build().execute();
+        assertThat(statusCode).isEqualTo(200);
+
+        RecordedRequest recordedRequest = mockServer.takeRequest();
+        assertThat(recordedRequest.getMethod()).isEqualTo("POST");
+        assertThat(recordedRequest.getHeader("Content-Type")).isEqualTo("application/json");
+        assertThat(recordedRequest.getBody().readString(StandardCharsets.UTF_8)).isEqualTo("\"test\"");
+    }
+
+    @Test
+    public void error_MissingResponseContentType() {
+        mockServer.enqueue(new MockResponse());
+        TestClient.ExecuteStage<HttpOptional<String>> executor = client.requestBuilder(new TypeReference<String>() {})
+                .get(mockServerUrl)
+                .build();
+        error_InvalidResponse(executor, "response Content-Type is missing");
+    }
+
+    @Test
+    public void error_InvalidResponseContentType() {
+        mockServer.enqueue(new MockResponse().setHeader("Content-Type", "abc"));
+        TestClient.ExecuteStage<HttpOptional<String>> executor = client.requestBuilder(new TypeReference<String>() {})
+                .get(mockServerUrl)
+                .build();
+        error_InvalidResponse(executor, "failed to parse response Content-Type: abc");
+    }
+
+    @Test
+    public void error_WrongResponseContentType() {
+        mockServer.enqueue(new MockResponse().setHeader("Content-Type", "text/html"));
+        TestClient.ExecuteStage<HttpOptional<String>> executor = client.requestBuilder(new TypeReference<String>() {})
+                .get(mockServerUrl)
+                .build();
+        error_InvalidResponse(executor, "response Content-Type is not application/json: text/html");
+    }
+
+    @Test
+    public void error_DeserializeResponseBodyFailed() {
+        mockServer.enqueue(
+                new MockResponse().setHeader("Content-Type", "application/json").setBody("{"));
+        TestClient.ExecuteStage<HttpOptional<String>> executor = client.requestBuilder(new TypeReference<String>() {})
+                .get(mockServerUrl)
+                .build();
+        error_InvalidResponse(executor, "deserialization failed");
+    }
+
+    private void error_InvalidResponse(TestClient.ExecuteStage<?> executor, String expectedMessage) {
+        assertThatThrownBy(() -> executor.execute())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(expectedMessage);
+    }
+
+    @Test
+    public void error_StageCompleted() {
+        ApiClient.UrlStageRequestBuilder<TestClient.ExecuteStage<Integer>> requestBuilder = client.requestBuilder();
+        requestBuilder.get(mockServerUrl);
+        assertThatThrownBy(() -> requestBuilder.get(mockServerUrl))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("stage already completed");
+    }
+
+    /** Test JSON API client. */
+    private static final class TestClient extends OkHttpJsonApiClient {
+
+        private static final OkHttpClient client = new OkHttpClient();
+
+        public static TestClient create() {
+            return new TestClient();
+        }
+
+        public UrlStageRequestBuilder<ExecuteStage<Integer>> requestBuilder() {
+            return requestBuilder(ExecuteStageImpl::new);
+        }
+
+        public <V> UrlStageRequestBuilder<ExecuteStage<HttpOptional<V>>> requestBuilder(
+                TypeReference<V> responseValueTypeRef) {
+            return requestBuilder(ExecuteStageImpl::new, responseValueTypeRef);
+        }
+
+        private TestClient() {}
+
+        /** Post-build stage that can synchronously execute the request. */
+        public interface ExecuteStage<V> {
+
+            V execute() throws IOException;
+        }
+
+        /** Internal {@link ExecuteStage} implementation. */
+        private record ExecuteStageImpl<V>(Request request, ResponseConverter<V> responseConverter)
+                implements ExecuteStage<V> {
+
+            @Override
+            public V execute() throws IOException {
+                Call call = client.newCall(request);
+                Response response = call.execute();
+                return responseConverter.convert(response);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- impls now define a post-build stage (type parameter `S`), instead of wrapping the client
    - wrapping a staged builder is a pain
- conversion of `Response` to a value is now handled internally
- slight downside: `build()` call is now added to the call chain

future PRs will transition impls to the redesigned API client 