### PR TITLE
refine API

### DIFF
--- a/api/src/main/resources/api.yaml
+++ b/api/src/main/resources/api.yaml
@@ -84,8 +84,8 @@ paths:
   /verification-request/{requestId}/link:
     post:
       tags: [avs]
-      description: Links the verification request to a user on the age verification service.
-      operationId: linkVerificationRequestToUser
+      description: Links the verification request to the person.
+      operationId: linkVerificationRequest
       parameters:
         - name: requestId
           description: ID of the verification request.
@@ -97,18 +97,11 @@ paths:
         '200':
           description: OK
 
-  /verification-request/{requestId}/age-certificate/send:
+  /age-certificate/send:
     post:
-      description: Sends an age certificate for the verification request.
+      description: Sends an age certificate for the person, using the linked verification request.
       tags: [avs]
-      operationId: sendAgeCertificateForVerificationRequest
-      parameters:
-        - name: requestId
-          description: ID of the verification request.
-          in: path
-          schema:
-            $ref: './age-certificate.yaml#/components/schemas/SecureId'
-          required: true
+      operationId: sendAgeCertificate
       responses:
         '200':
           description: OK

--- a/app/src/test/java/org/example/age/app/E2ETest.java
+++ b/app/src/test/java/org/example/age/app/E2ETest.java
@@ -78,12 +78,10 @@ public final class E2ETest {
         assertThat(request).isNotNull();
 
         Response<Void> linkResponse =
-                avsClient.linkVerificationRequestToUser(request.getId()).execute();
+                avsClient.linkVerificationRequest(request.getId()).execute();
         assertThat(linkResponse.isSuccessful()).isTrue();
 
-        Response<Void> certificateResponse = avsClient
-                .sendAgeCertificateForVerificationRequest(request.getId())
-                .execute();
+        Response<Void> certificateResponse = avsClient.sendAgeCertificate().execute();
         assertThat(certificateResponse.isSuccessful()).isTrue();
     }
 

--- a/service/src/main/java/org/example/age/service/AvsService.java
+++ b/service/src/main/java/org/example/age/service/AvsService.java
@@ -23,12 +23,12 @@ public final class AvsService implements AvsApi {
     }
 
     @Override
-    public CompletionStage<Void> linkVerificationRequestToUser(SecureId requestId) {
+    public CompletionStage<Void> linkVerificationRequest(SecureId requestId) {
         return CompletableFuture.completedFuture(null);
     }
 
     @Override
-    public CompletionStage<Void> sendAgeCertificateForVerificationRequest(SecureId requestId) {
+    public CompletionStage<Void> sendAgeCertificate() {
         return CompletableFuture.completedFuture(null);
     }
 }

--- a/service/src/main/java/org/example/age/service/SiteService.java
+++ b/service/src/main/java/org/example/age/service/SiteService.java
@@ -45,14 +45,14 @@ final class SiteService implements SiteApi {
             AccountIdExtractor accountIdExtractor,
             @Named("client") AvsApi avsClient,
             SiteVerificationStore verificationStore,
-            PendingStoreRepository pendingStoreRepository,
+            PendingStoreRepository pendingStores,
             AgeCertificateVerifier ageCertificateVerifier,
             SiteVerifiedUserLocalizer userLocalizer,
             SiteServiceConfig config) {
         this.accountIdExtractor = accountIdExtractor;
         this.avsClient = avsClient;
         this.verificationStore = verificationStore;
-        this.pendingRequestStore = pendingStoreRepository.get("request", String.class);
+        this.pendingRequestStore = pendingStores.get("request", String.class);
         this.ageCertificateVerifier = ageCertificateVerifier;
         this.userLocalizer = userLocalizer;
         this.config = config;

--- a/service/src/test/java/org/example/age/service/SiteServiceTest.java
+++ b/service/src/test/java/org/example/age/service/SiteServiceTest.java
@@ -176,12 +176,12 @@ public final class SiteServiceTest {
         }
 
         @Override
-        public Call<Void> linkVerificationRequestToUser(SecureId requestId) {
+        public Call<Void> linkVerificationRequest(SecureId requestId) {
             return Calls.failure(new UnsupportedOperationException());
         }
 
         @Override
-        public Call<Void> sendAgeCertificateForVerificationRequest(SecureId requestId) {
+        public Call<Void> sendAgeCertificate() {
             return Calls.failure(new UnsupportedOperationException());
         }
     }


### PR DESCRIPTION
- don't need to a request ID to send an age certificate
- refine operation ID and description