### PR TITLE
add config for client module

### DIFF
--- a/module/client/build.gradle.kts
+++ b/module/client/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    `java-library`
+    id("org.example.age.java-conventions")
+}
+
+dependencies {
+    annotationProcessor(libs.immutables.value)
+
+    api(project(":api"))
+    api(project(":service"))
+    api(libs.immutables.annotations)
+    api(libs.jackson.annotations)
+    api(libs.jackson.databind)
+
+    testImplementation(project(":testing"))
+}

--- a/module/client/src/main/java/org/example/age/module/client/AvsClientsConfig.java
+++ b/module/client/src/main/java/org/example/age/module/client/AvsClientsConfig.java
@@ -1,0 +1,32 @@
+package org.example.age.module.client;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.net.URL;
+import java.util.Map;
+import org.example.age.api.AvsApi;
+import org.example.age.api.client.SiteApi;
+import org.example.age.service.ConfigStyle;
+import org.immutables.value.Value;
+
+/** Configuration for the clients used by the service implementation of {@link AvsApi}. */
+@Value.Immutable
+@ConfigStyle
+@JsonSerialize
+@JsonDeserialize(as = ImmutableAvsClientsConfig.class)
+public interface AvsClientsConfig {
+
+    /** Creates a builder for the configuration. */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /** Base URLs of the clients for {@link SiteApi}, keyed by site ID. */
+    Map<String, URL> siteUrls();
+
+    /** Builder for the configuration. */
+    final class Builder extends ImmutableAvsClientsConfig.Builder {
+
+        Builder() {}
+    }
+}

--- a/module/client/src/main/java/org/example/age/module/client/SiteClientsConfig.java
+++ b/module/client/src/main/java/org/example/age/module/client/SiteClientsConfig.java
@@ -1,0 +1,31 @@
+package org.example.age.module.client;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.net.URL;
+import org.example.age.api.SiteApi;
+import org.example.age.api.client.AvsApi;
+import org.example.age.service.ConfigStyle;
+import org.immutables.value.Value;
+
+/** Configuration for the clients used by the service implementation of {@link SiteApi}. */
+@Value.Immutable
+@ConfigStyle
+@JsonSerialize
+@JsonDeserialize(as = ImmutableSiteClientsConfig.class)
+public interface SiteClientsConfig {
+
+    /** Creates a builder for the configuration. */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /** Base URL of the client for {@link AvsApi}. */
+    URL avsUrl();
+
+    /** Builder for the configuration. */
+    final class Builder extends ImmutableSiteClientsConfig.Builder {
+
+        Builder() {}
+    }
+}

--- a/module/client/src/test/java/org/example/age/module/client/AvsClientsConfigTest.java
+++ b/module/client/src/test/java/org/example/age/module/client/AvsClientsConfigTest.java
@@ -1,0 +1,20 @@
+package org.example.age.module.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import org.example.age.testing.TestObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public final class AvsClientsConfigTest {
+
+    @Test
+    public void serializeThenDeserialize() throws Exception {
+        AvsClientsConfig config = AvsClientsConfig.builder()
+                .putSiteUrls("site", new URI("http://localhost:8080").toURL())
+                .build();
+        String json = TestObjectMapper.get().writeValueAsString(config);
+        AvsClientsConfig rtConfig = TestObjectMapper.get().readValue(json, AvsClientsConfig.class);
+        assertThat(rtConfig).isEqualTo(config);
+    }
+}

--- a/module/client/src/test/java/org/example/age/module/client/SiteClientsConfigTest.java
+++ b/module/client/src/test/java/org/example/age/module/client/SiteClientsConfigTest.java
@@ -1,0 +1,20 @@
+package org.example.age.module.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import org.example.age.testing.TestObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public final class SiteClientsConfigTest {
+
+    @Test
+    public void serializeThenDeserialize() throws Exception {
+        SiteClientsConfig config = SiteClientsConfig.builder()
+                .avsUrl(new URI("http://localhost:8080").toURL())
+                .build();
+        String json = TestObjectMapper.get().writeValueAsString(config);
+        SiteClientsConfig rtConfig = TestObjectMapper.get().readValue(json, SiteClientsConfig.class);
+        assertThat(rtConfig).isEqualTo(config);
+    }
+}

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     api(project(":api"))
     api(libs.dagger.dagger)
     api(libs.immutables.annotations)
+    api(libs.jackson.annotations)
     api(libs.jackson.databind)
     implementation(libs.jakartaInject.api)
     implementation(libs.jaxRs.api)

--- a/service/src/main/java/org/example/age/service/AvsServiceConfig.java
+++ b/service/src/main/java/org/example/age/service/AvsServiceConfig.java
@@ -8,6 +8,7 @@ import org.immutables.value.Value;
 
 /** Configuration for the service implementation of {@link AvsApi}. */
 @Value.Immutable
+@ConfigStyle
 @JsonSerialize
 @JsonDeserialize(as = ImmutableAvsServiceConfig.class)
 public interface AvsServiceConfig {

--- a/service/src/main/java/org/example/age/service/ConfigStyle.java
+++ b/service/src/main/java/org/example/age/service/ConfigStyle.java
@@ -1,0 +1,7 @@
+package org.example.age.service;
+
+import org.immutables.value.Value;
+
+/** Style annotation for configuration interfaces. */
+@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE, overshadowImplementation = true)
+public @interface ConfigStyle {}

--- a/service/src/main/java/org/example/age/service/SiteServiceConfig.java
+++ b/service/src/main/java/org/example/age/service/SiteServiceConfig.java
@@ -8,6 +8,7 @@ import org.immutables.value.Value;
 
 /** Configuration for the service implementation of {@link SiteApi}. */
 @Value.Immutable
+@ConfigStyle
 @JsonSerialize
 @JsonDeserialize(as = ImmutableSiteServiceConfig.class)
 public interface SiteServiceConfig {

--- a/service/src/main/java/org/example/age/service/package-info.java
+++ b/service/src/main/java/org/example/age/service/package-info.java
@@ -1,4 +1,0 @@
-@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE, overshadowImplementation = true)
-package org.example.age.service;
-
-import org.immutables.value.Value;

--- a/service/src/test/java/org/example/age/service/AvsServiceTest.java
+++ b/service/src/test/java/org/example/age/service/AvsServiceTest.java
@@ -210,7 +210,7 @@ public final class AvsServiceTest {
     }
 
     /** Dagger component for the service. */
-    @Component(modules = {AvsServiceModule.class, FakeSiteClientModule.class, TestServiceDependenciesModule.class})
+    @Component(modules = {AvsServiceModule.class, FakeClientModule.class, TestServiceDependenciesModule.class})
     @Singleton
     interface TestComponent {
 
@@ -226,7 +226,7 @@ public final class AvsServiceTest {
 
     /** Dagger module that binds {@link SiteClientRepository}. */
     @Module
-    interface FakeSiteClientModule {
+    interface FakeClientModule {
 
         @Binds
         SiteClientRepository bindSiteClientRepository(FakeSiteClientRepository impl);

--- a/service/src/test/java/org/example/age/service/ServiceVerificationTest.java
+++ b/service/src/test/java/org/example/age/service/ServiceVerificationTest.java
@@ -132,7 +132,7 @@ public final class ServiceVerificationTest {
     }
 
     /** Dagger component for the site service. */
-    @Component(modules = {SiteServiceModule.class, TestAvsClientModule.class, TestServiceDependenciesModule.class})
+    @Component(modules = {SiteServiceModule.class, TestSiteClientModule.class, TestServiceDependenciesModule.class})
     @Singleton
     interface TestSiteComponent {
 
@@ -147,7 +147,7 @@ public final class ServiceVerificationTest {
     }
 
     /** Dagger component for the AVS service. */
-    @Component(modules = {AvsServiceModule.class, TestSiteClientModule.class, TestServiceDependenciesModule.class})
+    @Component(modules = {AvsServiceModule.class, TestAvsClientModule.class, TestServiceDependenciesModule.class})
     @Singleton
     interface TestAvsComponent {
 
@@ -163,7 +163,7 @@ public final class ServiceVerificationTest {
 
     /** Dagger module that binds <code>@Named("client") {@link org.example.age.api.client.AvsApi}</code>. */
     @Module
-    interface TestAvsClientModule {
+    interface TestSiteClientModule {
 
         @Binds
         @Named("client")
@@ -172,7 +172,7 @@ public final class ServiceVerificationTest {
 
     /** Dagger module that binds {@link SiteClientRepository}. */
     @Module
-    interface TestSiteClientModule {
+    interface TestAvsClientModule {
 
         @Binds
         SiteClientRepository bindSiteClientRepository(FakeSiteClientRepository impl);

--- a/service/src/test/java/org/example/age/service/SiteServiceTest.java
+++ b/service/src/test/java/org/example/age/service/SiteServiceTest.java
@@ -191,7 +191,7 @@ public final class SiteServiceTest {
     }
 
     /** Dagger component for the service. */
-    @Component(modules = {SiteServiceModule.class, FakeAvsClientModule.class, TestServiceDependenciesModule.class})
+    @Component(modules = {SiteServiceModule.class, FakeClientModule.class, TestServiceDependenciesModule.class})
     @Singleton
     interface TestComponent {
 
@@ -209,7 +209,7 @@ public final class SiteServiceTest {
 
     /** Dagger module that binds <code>@Named("client") {@link AvsApi}</code>. */
     @Module
-    interface FakeAvsClientModule {
+    interface FakeClientModule {
 
         @Binds
         @Named("client")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ include(
         "api:crypto",
         "service",
         "module:request-demo",
+        "module:client",
         "app",
 
         "testing",


### PR DESCRIPTION
related changes:

- add `@ConfigStyle` style annotation
- change naming convention for client modules in tests
- assume `libs.jackson.annotations` is needed whenever config classes exist