### PR TITLE
finetune error logic

### DIFF
--- a/module/client/src/main/java/org/example/age/module/client/SiteClientRepositoryImpl.java
+++ b/module/client/src/main/java/org/example/age/module/client/SiteClientRepositoryImpl.java
@@ -2,7 +2,7 @@ package org.example.age.module.client;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.NotFoundException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -23,7 +23,7 @@ final class SiteClientRepositoryImpl implements SiteClientRepository {
     @Override
     public SiteApi get(String siteId) {
         Optional<SiteApi> maybeClient = Optional.ofNullable(clients.get(siteId));
-        return maybeClient.orElseThrow(() -> new NotAuthorizedException("unregistered site"));
+        return maybeClient.orElseThrow(NotFoundException::new);
     }
 
     /** Creates the clients. */

--- a/module/client/src/test/java/org/example/age/module/client/AvsClientTest.java
+++ b/module/client/src/test/java/org/example/age/module/client/AvsClientTest.java
@@ -10,7 +10,7 @@ import io.dropwizard.core.Configuration;
 import io.dropwizard.core.setup.Environment;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import jakarta.inject.Singleton;
-import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.NotFoundException;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -52,7 +52,7 @@ public final class AvsClientTest {
 
     @Test
     public void error_UnregisteredSite() {
-        assertThatThrownBy(() -> siteClients.get("unregistered-site")).isInstanceOf(NotAuthorizedException.class);
+        assertThatThrownBy(() -> siteClients.get("unregistered-site")).isInstanceOf(NotFoundException.class);
     }
 
     /** Stub service implementation of {@link org.example.age.api.SiteApi}. */

--- a/service/api/src/main/java/org/example/age/service/api/client/SiteClientRepository.java
+++ b/service/api/src/main/java/org/example/age/service/api/client/SiteClientRepository.java
@@ -1,9 +1,9 @@
 package org.example.age.service.api.client;
 
-import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.NotFoundException;
 import org.example.age.api.client.SiteApi;
 
-/** Repository of clients for each site. Throws {@link NotAuthorizedException} if the site is not registered. */
+/** Repository of clients for each site. Throws {@link NotFoundException} if the site is not registered. */
 @FunctionalInterface
 public interface SiteClientRepository {
 

--- a/service/src/main/java/org/example/age/service/util/AsyncCalls.java
+++ b/service/src/main/java/org/example/age/service/util/AsyncCalls.java
@@ -1,10 +1,8 @@
 package org.example.age.service.util;
 
-import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.WebApplicationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.function.IntUnaryOperator;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -12,23 +10,10 @@ import retrofit2.Response;
 /** Adapts an asynchronous Retrofit call to a completion stage. */
 public final class AsyncCalls {
 
-    /**
-     * Makes an asynchronous {@link Call}, returning a {@link CompletionStage}
-     * that completes with a successful response or a 500 error.
-     */
+    /**  Makes an asynchronous {@link Call}, returning a corresponding {@link CompletionStage}. */
     public static <T> CompletionStage<T> make(Call<T> call) {
         CompletableFuture<T> future = new CompletableFuture<>();
-        call.enqueue(new FutureCallback<>(future, code -> 500));
-        return future;
-    }
-
-    /**
-     * Makes an asynchronous {@link Call}, returning a {@link CompletionStage}
-     * that completes with a successful response or an error code based on the response's error code.
-     */
-    public static <T> CompletionStage<T> make(Call<T> call, IntUnaryOperator errorCodeMapper) {
-        CompletableFuture<T> future = new CompletableFuture<>();
-        call.enqueue(new FutureCallback<>(future, errorCodeMapper));
+        call.enqueue(new FutureCallback<>(future));
         return future;
     }
 
@@ -36,16 +21,14 @@ public final class AsyncCalls {
     private AsyncCalls() {}
 
     /** Callback that completes a {@link CompletableFuture}. */
-    private record FutureCallback<T>(CompletableFuture<T> future, IntUnaryOperator errorCodeMapper)
-            implements Callback<T> {
+    private record FutureCallback<T>(CompletableFuture<T> future) implements Callback<T> {
 
         @Override
         public void onResponse(Call<T> call, Response<T> response) {
             if (!response.isSuccessful()) {
                 String message = String.format(
                         "%d error from %s", response.code(), call.request().url());
-                int errorCode = errorCodeMapper.applyAsInt(response.code());
-                future.completeExceptionally(new WebApplicationException(message, errorCode));
+                future.completeExceptionally(new WebApplicationException(message, response.code()));
                 return;
             }
 
@@ -54,9 +37,7 @@ public final class AsyncCalls {
 
         @Override
         public void onFailure(Call<T> call, Throwable throwable) {
-            String message =
-                    String.format("request to %s failed", call.request().url());
-            future.completeExceptionally(new InternalServerErrorException(message, throwable));
+            future.completeExceptionally(throwable);
         }
     }
 }

--- a/service/src/test/java/org/example/age/service/AvsServiceTest.java
+++ b/service/src/test/java/org/example/age/service/AvsServiceTest.java
@@ -10,7 +10,7 @@ import dagger.Module;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
-import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.NotFoundException;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -153,7 +153,7 @@ public final class AvsServiceTest {
     public void error_UnregisteredSite() {
         CompletionStage<VerificationRequest> requestResponse =
                 avsService.createVerificationRequestForSite("unregistered-site", EMPTY_DATA);
-        assertIsCompletedWithErrorCode(requestResponse, 401);
+        assertIsCompletedWithErrorCode(requestResponse, 404);
     }
 
     /** Fake implementation of {@link SiteClientRepository}. */
@@ -172,7 +172,7 @@ public final class AvsServiceTest {
         @Override
         public SiteApi get(String siteId) {
             if (!SITE_IDS.contains(siteId)) {
-                throw new NotAuthorizedException("unregistered site");
+                throw new NotFoundException();
             }
 
             return siteClient;

--- a/service/src/test/java/org/example/age/service/ServiceVerificationTest.java
+++ b/service/src/test/java/org/example/age/service/ServiceVerificationTest.java
@@ -8,7 +8,7 @@ import dagger.Module;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
-import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.NotFoundException;
 import java.util.concurrent.CompletionStage;
 import org.example.age.api.AuthMatchData;
 import org.example.age.api.AvsApi;
@@ -101,7 +101,7 @@ public final class ServiceVerificationTest {
         @Override
         public org.example.age.api.client.SiteApi get(String siteId) {
             if (!siteId.equals("site")) {
-                throw new NotAuthorizedException("unregistered site");
+                throw new NotFoundException();
             }
 
             return siteClient;

--- a/service/src/test/java/org/example/age/service/SiteServiceTest.java
+++ b/service/src/test/java/org/example/age/service/SiteServiceTest.java
@@ -115,7 +115,7 @@ public final class SiteServiceTest {
         VerificationRequest request = createVerificationRequest(Duration.ofMinutes(-1));
         SignedAgeCertificate signedAgeCertificate = createSignedAgeCertificate(request);
         CompletionStage<Void> certificateResponse = siteService.processAgeCertificate(signedAgeCertificate);
-        assertIsCompletedWithErrorCode(certificateResponse, 410);
+        assertIsCompletedWithErrorCode(certificateResponse, 404);
     }
 
     @Test


### PR DESCRIPTION
- simplify `AsyncCalls`: use passthrough logic for errors, push error handling to caller
- use 404 consistently for unregistered sites
- use 404 for expired age certificate