### PR TITLE
finetune config style

### DIFF
--- a/module/store-demo/build.gradle.kts
+++ b/module/store-demo/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     api(libs.immutables.annotations)
     api(libs.jackson.annotations)
     api(libs.jackson.databind)
+    implementation(libs.guava.guava)
     implementation(libs.jakartaInject.api)
 
     testAnnotationProcessor(libs.dagger.compiler)

--- a/service/api/src/main/java/org/example/age/service/api/config/ConfigStyle.java
+++ b/service/api/src/main/java/org/example/age/service/api/config/ConfigStyle.java
@@ -1,7 +1,14 @@
 package org.example.age.service.api.config;
 
+import org.immutables.value.Generated;
 import org.immutables.value.Value;
 
 /** Style annotation for configuration interfaces. */
-@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE, overshadowImplementation = true)
+@Value.Style(
+        visibility = Value.Style.ImplementationVisibility.PACKAGE,
+        overshadowImplementation = true,
+        jdk9Collections = true,
+        allowedClasspathAnnotations = {Generated.class, javax.annotation.processing.Generated.class},
+        defaults = @Value.Immutable(copy = false),
+        from = "")
 public @interface ConfigStyle {}


### PR DESCRIPTION
- Don't import a bunch of new things if Guava is on the classpath (`jdk9Collections`, `allowedClasspathAnnotations`).
- Don't generate a bunch of unused code (`defaults`, `from`).