### PR TITLE
fix testability issue for unit-testing services

### DIFF
--- a/module/request-demo/src/main/java/org/example/age/module/request/demo/DemoAccountIdContext.java
+++ b/module/request-demo/src/main/java/org/example/age/module/request/demo/DemoAccountIdContext.java
@@ -3,8 +3,8 @@ package org.example.age.module.request.demo;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.NotAuthorizedException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import java.util.Optional;
 import org.example.age.service.module.request.AccountIdContext;
 import org.example.age.service.module.request.RequestContextProvider;
 
@@ -23,10 +23,9 @@ final class DemoAccountIdContext implements AccountIdContext {
     }
 
     @Override
-    public CompletionStage<String> getForRequest() {
-        String accountId = requestContextProvider.get().getHeaderString("Account-Id");
-        return (accountId != null)
-                ? CompletableFuture.completedFuture(accountId)
-                : CompletableFuture.failedFuture(new NotAuthorizedException("failed to authenticate account"));
+    public String getForRequest() {
+        ContainerRequestContext requestContext = requestContextProvider.get();
+        return Optional.ofNullable(requestContext.getHeaderString("Account-Id"))
+                .orElseThrow(() -> new NotAuthorizedException("failed to authenticate account"));
     }
 }

--- a/module/request-demo/src/test/java/org/example/age/module/request/demo/DemoAccountIdTest.java
+++ b/module/request-demo/src/test/java/org/example/age/module/request/demo/DemoAccountIdTest.java
@@ -14,7 +14,6 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
-import java.util.concurrent.CompletionStage;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.example.age.service.module.request.AccountIdContext;
@@ -63,7 +62,7 @@ public final class DemoAccountIdTest {
 
         @GET
         @Produces(MediaType.TEXT_PLAIN)
-        public CompletionStage<String> accountId() {
+        public String accountId() {
             return accountIdContext.getForRequest();
         }
     }

--- a/service/module/src/main/java/org/example/age/service/module/request/AccountIdContext.java
+++ b/service/module/src/main/java/org/example/age/service/module/request/AccountIdContext.java
@@ -1,7 +1,6 @@
 package org.example.age.service.module.request;
 
 import jakarta.ws.rs.NotAuthorizedException;
-import java.util.concurrent.CompletionStage;
 
 /**
  * Gets the account ID for the HTTP request, or throws {@link NotAuthorizedException}.
@@ -10,5 +9,5 @@ import java.util.concurrent.CompletionStage;
 @FunctionalInterface
 public interface AccountIdContext {
 
-    CompletionStage<String> getForRequest();
+    String getForRequest();
 }

--- a/service/src/main/java/org/example/age/service/SiteService.java
+++ b/service/src/main/java/org/example/age/service/SiteService.java
@@ -63,17 +63,15 @@ final class SiteService implements SiteApi {
 
     @Override
     public CompletionStage<VerificationState> getVerificationState() {
-        return accountIdContext.getForRequest().thenCompose(verificationStore::load);
+        String accountId = accountIdContext.getForRequest();
+        return verificationStore.load(accountId);
     }
 
     @Override
     public CompletionStage<VerificationRequest> createVerificationRequest() {
-        CompletionStage<String> accountStage = accountIdContext.getForRequest();
-        CompletionStage<VerificationRequest> requestStage =
-                accountStage.thenCompose(accountId -> createVerificationRequestForThisSite());
-        return requestStage
-                .thenCombine(accountStage, this::linkVerificationRequestToAccount)
-                .thenCompose(Function.identity());
+        String accountId = accountIdContext.getForRequest();
+        return createVerificationRequestForThisSite()
+                .thenCompose(request -> linkVerificationRequestToAccount(request, accountId));
     }
 
     @Override

--- a/service/src/test/java/org/example/age/service/AvsServiceTest.java
+++ b/service/src/test/java/org/example/age/service/AvsServiceTest.java
@@ -29,6 +29,7 @@ import org.example.age.api.crypto.SecureId;
 import org.example.age.service.module.client.SiteClientRepository;
 import org.example.age.service.module.crypto.AgeCertificateVerifier;
 import org.example.age.service.testing.TestDependenciesModule;
+import org.example.age.service.testing.TestWrappedAvsService;
 import org.example.age.service.testing.request.TestAccountId;
 import org.example.age.testing.CompletionStageTesting;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,7 +49,7 @@ public final class AvsServiceTest {
     @BeforeEach
     public void createAvsServiceEtAl() {
         TestComponent component = TestComponent.create();
-        avsService = component.avsService();
+        avsService = new TestWrappedAvsService(component.avsService());
         accountId = component.accountId();
         ageCertificate = null;
     }

--- a/service/src/test/java/org/example/age/service/ServiceVerificationTest.java
+++ b/service/src/test/java/org/example/age/service/ServiceVerificationTest.java
@@ -21,6 +21,8 @@ import org.example.age.api.VerificationStatus;
 import org.example.age.api.crypto.SecureId;
 import org.example.age.service.module.client.SiteClientRepository;
 import org.example.age.service.testing.TestDependenciesModule;
+import org.example.age.service.testing.TestWrappedAvsService;
+import org.example.age.service.testing.TestWrappedSiteService;
 import org.example.age.service.testing.request.TestAccountId;
 import org.example.age.testing.CompletionStageTesting;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,10 +40,10 @@ public final class ServiceVerificationTest {
     @BeforeEach
     public void createServicesEtAl() {
         TestSiteComponent siteComponent = TestSiteComponent.create();
-        siteService = siteComponent.service();
+        siteService = new TestWrappedSiteService(siteComponent.service());
         siteAccountId = siteComponent.accountId();
         TestAvsComponent avsComponent = TestAvsComponent.create();
-        avsService = avsComponent.service();
+        avsService = new TestWrappedAvsService(avsComponent.service());
         avsAccountId = avsComponent.accountId();
     }
 

--- a/service/src/test/java/org/example/age/service/SiteServiceTest.java
+++ b/service/src/test/java/org/example/age/service/SiteServiceTest.java
@@ -29,6 +29,7 @@ import org.example.age.api.crypto.SecureId;
 import org.example.age.api.crypto.SignatureData;
 import org.example.age.service.module.crypto.AgeCertificateSigner;
 import org.example.age.service.testing.TestDependenciesModule;
+import org.example.age.service.testing.TestWrappedSiteService;
 import org.example.age.service.testing.request.TestAccountId;
 import org.example.age.testing.TestModels;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,7 +46,7 @@ public final class SiteServiceTest {
     @BeforeEach
     public void createSiteServiceEtAl() {
         TestComponent component = TestComponent.create();
-        siteService = component.siteService();
+        siteService = new TestWrappedSiteService(component.siteService());
         accountId = component.accountId();
         ageCertificateSigner = component.ageCertificateSigner();
     }

--- a/service/src/test/java/org/example/age/service/testing/TestWrappedAvsService.java
+++ b/service/src/test/java/org/example/age/service/testing/TestWrappedAvsService.java
@@ -1,0 +1,40 @@
+package org.example.age.service.testing;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.example.age.api.AuthMatchData;
+import org.example.age.api.AvsApi;
+import org.example.age.api.VerificationRequest;
+import org.example.age.api.crypto.SecureId;
+
+/** Wrapper that converts uncaught exceptions to failed futures. */
+public record TestWrappedAvsService(AvsApi delegate) implements AvsApi {
+
+    @Override
+    public CompletionStage<VerificationRequest> createVerificationRequestForSite(
+            String siteId, AuthMatchData authMatchData) {
+        try {
+            return delegate.createVerificationRequestForSite(siteId, authMatchData);
+        } catch (RuntimeException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    @Override
+    public CompletionStage<Void> linkVerificationRequest(SecureId requestId) {
+        try {
+            return delegate.linkVerificationRequest(requestId);
+        } catch (RuntimeException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    @Override
+    public CompletionStage<Void> sendAgeCertificate() {
+        try {
+            return delegate.sendAgeCertificate();
+        } catch (RuntimeException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+}

--- a/service/src/test/java/org/example/age/service/testing/TestWrappedSiteService.java
+++ b/service/src/test/java/org/example/age/service/testing/TestWrappedSiteService.java
@@ -1,0 +1,39 @@
+package org.example.age.service.testing;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.example.age.api.SignedAgeCertificate;
+import org.example.age.api.SiteApi;
+import org.example.age.api.VerificationRequest;
+import org.example.age.api.VerificationState;
+
+/** Wrapper that converts uncaught exceptions to failed futures. */
+public record TestWrappedSiteService(SiteApi delegate) implements SiteApi {
+
+    @Override
+    public CompletionStage<VerificationState> getVerificationState() {
+        try {
+            return delegate.getVerificationState();
+        } catch (RuntimeException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    @Override
+    public CompletionStage<VerificationRequest> createVerificationRequest() {
+        try {
+            return delegate.createVerificationRequest();
+        } catch (RuntimeException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    @Override
+    public CompletionStage<Void> processAgeCertificate(SignedAgeCertificate signedAgeCertificate) {
+        try {
+            return delegate.processAgeCertificate(signedAgeCertificate);
+        } catch (RuntimeException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+}

--- a/service/src/test/java/org/example/age/service/testing/request/FakeAccountIdContext.java
+++ b/service/src/test/java/org/example/age/service/testing/request/FakeAccountIdContext.java
@@ -3,28 +3,25 @@ package org.example.age.service.testing.request;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.NotAuthorizedException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+import java.util.Optional;
 import org.example.age.service.module.request.AccountIdContext;
 
 /** Fake implementation of {@link AccountIdContext}. */
 @Singleton
 final class FakeAccountIdContext implements AccountIdContext {
 
-    private String accountId = null;
+    private Optional<String> maybeAccountId = Optional.empty();
 
     @Inject
     public FakeAccountIdContext() {}
 
     @Override
-    public CompletionStage<String> getForRequest() {
-        return (accountId != null)
-                ? CompletableFuture.completedFuture(accountId)
-                : CompletableFuture.failedFuture(new NotAuthorizedException("failed to authenticate account"));
+    public String getForRequest() {
+        return maybeAccountId.orElseThrow(() -> new NotAuthorizedException("failed to authenticate account"));
     }
 
     /** Sets the account ID. */
     public void set(String accountId) {
-        this.accountId = accountId;
+        maybeAccountId = Optional.of(accountId);
     }
 }


### PR DESCRIPTION
- Add test wrappers that turn uncaught exceptions to failed futures.
- Now, it's OK for testing if a service  throws an exception instead of returning a failed future.
    - Namely, `AccountIdContext` can return `String` instead of `CompletionStage<String>`.
- For the application, an uncaught exception and a failed future with said exception produce the same result.