### PR TITLE
move localization code to api module

### DIFF
--- a/api/src/main/java/org/example/age/api/crypto/Localization.java
+++ b/api/src/main/java/org/example/age/api/crypto/Localization.java
@@ -1,8 +1,7 @@
-package org.example.age.service.module.crypto;
+package org.example.age.api.crypto;
 
 import java.util.List;
 import org.example.age.api.VerifiedUser;
-import org.example.age.api.crypto.SecureId;
 
 /** Localizes verified users using a localization key. */
 public final class Localization {

--- a/api/src/test/java/org/example/age/api/crypto/LocalizationTest.java
+++ b/api/src/test/java/org/example/age/api/crypto/LocalizationTest.java
@@ -1,11 +1,10 @@
-package org.example.age.service.module.crypto;
+package org.example.age.api.crypto;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import org.example.age.api.AgeRange;
 import org.example.age.api.VerifiedUser;
-import org.example.age.api.crypto.SecureId;
 import org.junit.jupiter.api.Test;
 
 public final class LocalizationTest {

--- a/module/crypto-demo/src/main/java/org/example/age/module/crypto/demo/DemoAvsVerifiedUserLocalizer.java
+++ b/module/crypto-demo/src/main/java/org/example/age/module/crypto/demo/DemoAvsVerifiedUserLocalizer.java
@@ -6,9 +6,9 @@ import jakarta.ws.rs.NotFoundException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.example.age.api.VerifiedUser;
+import org.example.age.api.crypto.Localization;
 import org.example.age.api.crypto.SecureId;
 import org.example.age.service.module.crypto.AvsVerifiedUserLocalizer;
-import org.example.age.service.module.crypto.Localization;
 
 /**
  * Implementation of {@link AvsVerifiedUserLocalizer}.

--- a/module/crypto-demo/src/main/java/org/example/age/module/crypto/demo/DemoSiteVerifiedUserLocalizer.java
+++ b/module/crypto-demo/src/main/java/org/example/age/module/crypto/demo/DemoSiteVerifiedUserLocalizer.java
@@ -5,7 +5,7 @@ import jakarta.inject.Singleton;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.example.age.api.VerifiedUser;
-import org.example.age.service.module.crypto.Localization;
+import org.example.age.api.crypto.Localization;
 import org.example.age.service.module.crypto.SiteVerifiedUserLocalizer;
 
 /**

--- a/service/src/test/java/org/example/age/service/testing/crypto/FakeAvsVerifiedUserLocalizer.java
+++ b/service/src/test/java/org/example/age/service/testing/crypto/FakeAvsVerifiedUserLocalizer.java
@@ -7,9 +7,9 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.example.age.api.VerifiedUser;
+import org.example.age.api.crypto.Localization;
 import org.example.age.api.crypto.SecureId;
 import org.example.age.service.module.crypto.AvsVerifiedUserLocalizer;
-import org.example.age.service.module.crypto.Localization;
 
 /** Fake implementation of {@link AvsVerifiedUserLocalizer}. */
 @Singleton

--- a/service/src/test/java/org/example/age/service/testing/crypto/FakeSiteVerifiedUserLocalizer.java
+++ b/service/src/test/java/org/example/age/service/testing/crypto/FakeSiteVerifiedUserLocalizer.java
@@ -5,8 +5,8 @@ import jakarta.inject.Singleton;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.example.age.api.VerifiedUser;
+import org.example.age.api.crypto.Localization;
 import org.example.age.api.crypto.SecureId;
-import org.example.age.service.module.crypto.Localization;
 import org.example.age.service.module.crypto.SiteVerifiedUserLocalizer;
 
 /** Fake implementation of {@link SiteVerifiedUserLocalizer}. */


### PR DESCRIPTION
It's an extension of `VerifiedUser`. Thanks to the previous PR, hand-coded types can now depend on generated types.