### PR TITLE
reduce test boilerplate

### DIFF
--- a/app/src/test/java/org/example/age/app/AppVerificationTest.java
+++ b/app/src/test/java/org/example/age/app/AppVerificationTest.java
@@ -85,6 +85,6 @@ public final class AppVerificationTest {
     }
 
     private static <A> A createClient(int port, String accountId, Class<A> apiType) {
-        return TestClient.createApi(port, requestBuilder -> requestBuilder.header("Account-Id", accountId), apiType);
+        return TestClient.api(port, requestBuilder -> requestBuilder.header("Account-Id", accountId), apiType);
     }
 }

--- a/common/src/test/java/org/example/age/common/testing/TestClientTest.java
+++ b/common/src/test/java/org/example/age/common/testing/TestClientTest.java
@@ -29,14 +29,14 @@ public final class TestClientTest {
 
     @Test
     public void getHttp() {
-        OkHttpClient client = TestClient.getHttp();
+        OkHttpClient client = TestClient.http();
         assertThat(client).isNotNull();
-        assertThat(client).isSameAs(TestClient.getHttp());
+        assertThat(client).isSameAs(TestClient.http());
     }
 
     @Test
     public void createApi() throws IOException {
-        TestApi client = TestClient.createApi(
+        TestApi client = TestClient.api(
                 app.getLocalPort(), requestBuilder -> requestBuilder.header("Test-Header", "value"), TestApi.class);
         Response<Map<String, String>> response = client.test().execute();
         assertThat(response.isSuccessful()).isTrue();
@@ -45,7 +45,7 @@ public final class TestClientTest {
 
     @Test
     public void createLocalhostUrl() {
-        URL url = TestClient.createLocalhostUrl(8080);
+        URL url = TestClient.localhostUrl(8080);
         assertThat(url.toString()).isEqualTo("http://localhost:8080");
     }
 

--- a/common/src/testFixtures/java/org/example/age/common/testing/TestClient.java
+++ b/common/src/testFixtures/java/org/example/age/common/testing/TestClient.java
@@ -21,38 +21,37 @@ public final class TestClient {
             JacksonConverterFactory.create(TestObjectMapper.get());
 
     /** Gets the HTTP client. */
-    public static OkHttpClient getHttp() {
+    public static OkHttpClient http() {
         return client;
     }
 
     /** Creates an API client. */
-    public static <A> A createApi(int port, Consumer<Request.Builder> requestInterceptor, Class<A> apiType) {
+    public static <A> A api(int port, Consumer<Request.Builder> requestInterceptor, Class<A> apiType) {
         return new Retrofit.Builder()
-                .baseUrl(createLocalhostUrl(port))
-                .client(createHttp(requestInterceptor))
+                .baseUrl(localhostUrl(port))
+                .client(http(requestInterceptor))
                 .addConverterFactory(jsonConverterFactory)
                 .build()
                 .create(apiType);
     }
 
     /** Creates a URL for localhost. */
-    public static URL createLocalhostUrl(int port) {
+    public static URL localhostUrl(int port) {
         try {
-            return createLocalhostUri(port).toURL();
+            return localhostUri(port).toURL();
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
     }
 
     /** Creates a URI for localhost. */
-    public static URI createLocalhostUri(int port) {
+    public static URI localhostUri(int port) {
         return URI.create(String.format("http://localhost:%d", port));
     }
 
     /** Creates an HTTP client that intercepts the request. */
-    private static OkHttpClient createHttp(Consumer<Request.Builder> requestInterceptor) {
-        return TestClient.getHttp()
-                .newBuilder()
+    private static OkHttpClient http(Consumer<Request.Builder> requestInterceptor) {
+        return http().newBuilder()
                 .addInterceptor(chain -> interceptRequest(chain, requestInterceptor))
                 .build();
     }

--- a/demo/src/main/java/org/example/age/demo/Demo.java
+++ b/demo/src/main/java/org/example/age/demo/Demo.java
@@ -89,7 +89,7 @@ public final class Demo {
 
     /** Creates a client for an account. */
     private static <A> A createClient(int port, String accountId, Class<A> apiType) {
-        return TestClient.createApi(port, requestBuilder -> requestBuilder.header("Account-Id", accountId), apiType);
+        return TestClient.api(port, requestBuilder -> requestBuilder.header("Account-Id", accountId), apiType);
     }
 
     /** Sets up the demo. */

--- a/module/client/src/test/java/org/example/age/module/client/AvsClientsConfigTest.java
+++ b/module/client/src/test/java/org/example/age/module/client/AvsClientsConfigTest.java
@@ -8,6 +8,6 @@ public final class AvsClientsConfigTest {
 
     @Test
     public void serializeThenDeserialize() throws Exception {
-        JsonTesting.serializeThenDeserialize(TestConfig.createAvsClients(8080), AvsClientsConfig.class);
+        JsonTesting.serializeThenDeserialize(TestConfig.avsClients(), AvsClientsConfig.class);
     }
 }

--- a/module/client/src/test/java/org/example/age/module/client/SiteClientTest.java
+++ b/module/client/src/test/java/org/example/age/module/client/SiteClientTest.java
@@ -1,33 +1,23 @@
 package org.example.age.module.client;
 
-import dagger.BindsInstance;
 import dagger.Component;
 import io.dropwizard.core.Application;
 import io.dropwizard.core.Configuration;
 import io.dropwizard.core.setup.Environment;
-import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import org.example.age.api.client.AvsApi;
 import org.example.age.module.client.testing.TestDependenciesModule;
 import org.example.age.service.module.client.testing.SiteClientTestTemplate;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public final class SiteClientTest extends SiteClientTestTemplate {
 
+    private static final AvsApi avsClient = TestComponent.create();
+
     @RegisterExtension
-    private static final DropwizardAppExtension<Configuration> app =
-            new DropwizardAppExtension<>(TestApp.class, null, ConfigOverride.randomPorts());
-
-    private static AvsApi avsClient;
-
-    @BeforeAll
-    public static void createClients() {
-        TestComponent component = TestComponent.create(app.getLocalPort());
-        avsClient = component.avsClient();
-    }
+    private static final DropwizardAppExtension<Configuration> app = new DropwizardAppExtension<>(TestApp.class);
 
     @Override
     protected AvsApi avsClient() {
@@ -43,22 +33,16 @@ public final class SiteClientTest extends SiteClientTestTemplate {
         }
     }
 
-    /** Dagger component for the clients. */
+    /** Dagger component for the <code>@Named("client") {@link AvsApi}</code>. */
     @Component(modules = {SiteClientModule.class, TestDependenciesModule.class})
     @Singleton
     interface TestComponent {
 
-        static TestComponent create(int port) {
-            return DaggerSiteClientTest_TestComponent.factory().create(port);
+        static AvsApi create() {
+            return DaggerSiteClientTest_TestComponent.create().get();
         }
 
         @Named("client")
-        AvsApi avsClient();
-
-        @Component.Factory
-        interface Factory {
-
-            TestComponent create(@BindsInstance @Named("port") int port);
-        }
+        AvsApi get();
     }
 }

--- a/module/client/src/test/java/org/example/age/module/client/SiteClientsConfigTest.java
+++ b/module/client/src/test/java/org/example/age/module/client/SiteClientsConfigTest.java
@@ -8,6 +8,6 @@ public final class SiteClientsConfigTest {
 
     @Test
     public void serializeThenDeserialize() throws Exception {
-        JsonTesting.serializeThenDeserialize(TestConfig.createSiteClients(8080), SiteClientsConfig.class);
+        JsonTesting.serializeThenDeserialize(TestConfig.siteClients(), SiteClientsConfig.class);
     }
 }

--- a/module/client/src/test/java/org/example/age/module/client/testing/TestConfig.java
+++ b/module/client/src/test/java/org/example/age/module/client/testing/TestConfig.java
@@ -7,18 +7,20 @@ import org.example.age.module.client.SiteClientsConfig;
 /** Configuration for testing. */
 public class TestConfig {
 
+    private static SiteClientsConfig siteClients =
+            SiteClientsConfig.builder().avsUrl(TestClient.localhostUrl(8080)).build();
+    private static AvsClientsConfig avsClients = AvsClientsConfig.builder()
+            .putSiteUrls("site", TestClient.localhostUrl(8080))
+            .build();
+
     /** Creates the configuration for clients on the site. */
-    public static SiteClientsConfig createSiteClients(int port) {
-        return SiteClientsConfig.builder()
-                .avsUrl(TestClient.createLocalhostUrl(port))
-                .build();
+    public static SiteClientsConfig siteClients() {
+        return siteClients;
     }
 
     /** Creates the configuration for clients on the age verification service. */
-    public static AvsClientsConfig createAvsClients(int port) {
-        return AvsClientsConfig.builder()
-                .putSiteUrls("site", TestClient.createLocalhostUrl(port))
-                .build();
+    public static AvsClientsConfig avsClients() {
+        return avsClients;
     }
 
     private TestConfig() {} // static class

--- a/module/client/src/test/java/org/example/age/module/client/testing/TestDependenciesModule.java
+++ b/module/client/src/test/java/org/example/age/module/client/testing/TestDependenciesModule.java
@@ -2,8 +2,6 @@ package org.example.age.module.client.testing;
 
 import dagger.Module;
 import dagger.Provides;
-import jakarta.inject.Named;
-import jakarta.inject.Singleton;
 import org.example.age.module.client.AvsClientsConfig;
 import org.example.age.module.client.SiteClientsConfig;
 import org.example.age.module.common.LiteEnv;
@@ -16,21 +14,17 @@ import org.example.age.module.common.testing.TestLiteEnvModule;
  *     <li>{@link AvsClientsConfig}
  *     <li>{@link LiteEnv}
  * </ul>
- * <p>
- * Depends on an unbound <code>@Named("port") int</code>.
  */
 @Module(includes = TestLiteEnvModule.class)
 public interface TestDependenciesModule {
 
     @Provides
-    @Singleton
-    static SiteClientsConfig provideSiteClientsConfig(@Named("port") int port) {
-        return TestConfig.createSiteClients(port);
+    static SiteClientsConfig provideSiteClientsConfig() {
+        return TestConfig.siteClients();
     }
 
     @Provides
-    @Singleton
-    static AvsClientsConfig provideAvsClientsConfig(@Named("port") int port) {
-        return TestConfig.createAvsClients(port);
+    static AvsClientsConfig provideAvsClientsConfig() {
+        return TestConfig.avsClients();
     }
 }

--- a/module/common/src/test/java/org/example/age/module/common/JsonTest.java
+++ b/module/common/src/test/java/org/example/age/module/common/JsonTest.java
@@ -4,19 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dagger.Component;
 import jakarta.inject.Singleton;
+import java.util.function.Supplier;
 import org.example.age.module.common.testing.TestLiteEnvModule;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public final class JsonTest {
 
-    private static JsonMapper mapper;
-
-    @BeforeAll
-    public static void createJsonMapper() {
-        TestComponent component = TestComponent.create();
-        mapper = component.jsonMapper();
-    }
+    private static final JsonMapper mapper = TestComponent.create();
 
     @Test
     public void serializeThenDeserialize() {
@@ -25,15 +19,13 @@ public final class JsonTest {
         assertThat(value).isEqualTo("test");
     }
 
-    /** Dagger component for the environment. */
+    /** Dagger component for {@link JsonMapper}. */
     @Component(modules = {CommonModule.class, TestLiteEnvModule.class})
     @Singleton
-    interface TestComponent {
+    interface TestComponent extends Supplier<JsonMapper> {
 
-        static TestComponent create() {
-            return DaggerJsonTest_TestComponent.create();
+        static JsonMapper create() {
+            return DaggerJsonTest_TestComponent.create().get();
         }
-
-        JsonMapper jsonMapper();
     }
 }

--- a/module/common/src/test/java/org/example/age/module/common/WorkerTest.java
+++ b/module/common/src/test/java/org/example/age/module/common/WorkerTest.java
@@ -5,19 +5,13 @@ import static org.example.age.common.testing.WebStageTesting.await;
 
 import dagger.Component;
 import jakarta.inject.Singleton;
+import java.util.function.Supplier;
 import org.example.age.module.common.testing.TestLiteEnvModule;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public final class WorkerTest {
 
-    private static Worker worker;
-
-    @BeforeAll
-    public static void createWorker() {
-        TestComponent component = TestComponent.create();
-        worker = component.worker();
-    }
+    private static final Worker worker = TestComponent.create();
 
     @Test
     public void dispatch() {
@@ -25,15 +19,13 @@ public final class WorkerTest {
         assertThat(value).isEqualTo(1);
     }
 
-    /** Dagger component for the environment. */
+    /** Dagger component for {@link Worker}. */
     @Component(modules = {CommonModule.class, TestLiteEnvModule.class})
     @Singleton
-    interface TestComponent {
+    interface TestComponent extends Supplier<Worker> {
 
-        static TestComponent create() {
-            return DaggerWorkerTest_TestComponent.create();
+        static Worker create() {
+            return DaggerWorkerTest_TestComponent.create().get();
         }
-
-        Worker worker();
     }
 }

--- a/module/crypto-demo/src/test/java/org/example/age/module/crypto/demo/DemoAgeCertificateSignerVerifierTest.java
+++ b/module/crypto-demo/src/test/java/org/example/age/module/crypto/demo/DemoAgeCertificateSignerVerifierTest.java
@@ -2,24 +2,16 @@ package org.example.age.module.crypto.demo;
 
 import dagger.Component;
 import jakarta.inject.Singleton;
+import java.util.function.Supplier;
 import org.example.age.module.crypto.demo.testing.TestDependenciesModule;
 import org.example.age.service.module.crypto.AgeCertificateSigner;
 import org.example.age.service.module.crypto.AgeCertificateVerifier;
 import org.example.age.service.module.crypto.testing.AgeCertificateSignerVerifierTestTemplate;
-import org.junit.jupiter.api.BeforeAll;
 
 public final class DemoAgeCertificateSignerVerifierTest extends AgeCertificateSignerVerifierTestTemplate {
 
-    private static AgeCertificateSigner signer;
-    private static AgeCertificateVerifier verifier;
-
-    @BeforeAll
-    public static void createAgeCertificateSignerAndVerifier() {
-        TestAvsComponent avsComponent = TestAvsComponent.create();
-        signer = avsComponent.ageCertificateSigner();
-        TestSiteComponent siteComponent = TestSiteComponent.create();
-        verifier = siteComponent.ageCertificateVerifier();
-    }
+    private static final AgeCertificateSigner signer = TestAvsComponent.create();
+    private static final AgeCertificateVerifier verifier = TestSiteComponent.create();
 
     @Override
     protected AgeCertificateSigner signer() {
@@ -31,27 +23,25 @@ public final class DemoAgeCertificateSignerVerifierTest extends AgeCertificateSi
         return verifier;
     }
 
-    /** Dagger component for crypto. */
+    /** Dagger component for {@link AgeCertificateSigner}. */
     @Component(modules = {DemoAvsCryptoModule.class, TestDependenciesModule.class})
     @Singleton
-    interface TestAvsComponent {
+    interface TestAvsComponent extends Supplier<AgeCertificateSigner> {
 
-        static TestAvsComponent create() {
-            return DaggerDemoAgeCertificateSignerVerifierTest_TestAvsComponent.create();
+        static AgeCertificateSigner create() {
+            return DaggerDemoAgeCertificateSignerVerifierTest_TestAvsComponent.create()
+                    .get();
         }
-
-        AgeCertificateSigner ageCertificateSigner();
     }
 
-    /** Dagger component for crypto. */
+    /** Dagger component for {@link AgeCertificateVerifier}. */
     @Component(modules = {DemoSiteCryptoModule.class, TestDependenciesModule.class})
     @Singleton
-    interface TestSiteComponent {
+    interface TestSiteComponent extends Supplier<AgeCertificateVerifier> {
 
-        static TestSiteComponent create() {
-            return DaggerDemoAgeCertificateSignerVerifierTest_TestSiteComponent.create();
+        static AgeCertificateVerifier create() {
+            return DaggerDemoAgeCertificateSignerVerifierTest_TestSiteComponent.create()
+                    .get();
         }
-
-        AgeCertificateVerifier ageCertificateVerifier();
     }
 }

--- a/module/crypto-demo/src/test/java/org/example/age/module/crypto/demo/DemoAvsVerifiedUserLocalizerTest.java
+++ b/module/crypto-demo/src/test/java/org/example/age/module/crypto/demo/DemoAvsVerifiedUserLocalizerTest.java
@@ -2,35 +2,27 @@ package org.example.age.module.crypto.demo;
 
 import dagger.Component;
 import jakarta.inject.Singleton;
+import java.util.function.Supplier;
 import org.example.age.module.crypto.demo.testing.TestDependenciesModule;
 import org.example.age.service.module.crypto.AvsVerifiedUserLocalizer;
 import org.example.age.service.module.crypto.testing.AvsVerifiedUserLocalizerTestTemplate;
-import org.junit.jupiter.api.BeforeAll;
 
 public final class DemoAvsVerifiedUserLocalizerTest extends AvsVerifiedUserLocalizerTestTemplate {
 
-    private static AvsVerifiedUserLocalizer localizer;
-
-    @BeforeAll
-    public static void createVerifiedUserLocalizer() {
-        TestComponent component = TestComponent.create();
-        localizer = component.verifiedUserLocalizer();
-    }
+    private static final AvsVerifiedUserLocalizer localizer = TestComponent.create();
 
     @Override
     protected AvsVerifiedUserLocalizer localizer() {
         return localizer;
     }
 
-    /** Dagger component for crypto. */
+    /** Dagger component for {@link AvsVerifiedUserLocalizer}. */
     @Component(modules = {DemoAvsCryptoModule.class, TestDependenciesModule.class})
     @Singleton
-    interface TestComponent {
+    interface TestComponent extends Supplier<AvsVerifiedUserLocalizer> {
 
-        static TestComponent create() {
-            return DaggerDemoAvsVerifiedUserLocalizerTest_TestComponent.create();
+        static AvsVerifiedUserLocalizer create() {
+            return DaggerDemoAvsVerifiedUserLocalizerTest_TestComponent.create().get();
         }
-
-        AvsVerifiedUserLocalizer verifiedUserLocalizer();
     }
 }

--- a/module/crypto-demo/src/test/java/org/example/age/module/crypto/demo/DemoSiteVerifiedUserLocalizerTest.java
+++ b/module/crypto-demo/src/test/java/org/example/age/module/crypto/demo/DemoSiteVerifiedUserLocalizerTest.java
@@ -2,35 +2,28 @@ package org.example.age.module.crypto.demo;
 
 import dagger.Component;
 import jakarta.inject.Singleton;
+import java.util.function.Supplier;
 import org.example.age.module.crypto.demo.testing.TestDependenciesModule;
 import org.example.age.service.module.crypto.SiteVerifiedUserLocalizer;
 import org.example.age.service.module.crypto.testing.SiteVerifiedUserLocalizerTestTemplate;
-import org.junit.jupiter.api.BeforeAll;
 
 public final class DemoSiteVerifiedUserLocalizerTest extends SiteVerifiedUserLocalizerTestTemplate {
 
-    private static SiteVerifiedUserLocalizer localizer;
-
-    @BeforeAll
-    public static void createVerifiedUserLocalizer() {
-        TestComponent component = TestComponent.create();
-        localizer = component.verifiedUserLocalizer();
-    }
+    private static final SiteVerifiedUserLocalizer localizer = TestComponent.create();
 
     @Override
     protected SiteVerifiedUserLocalizer localizer() {
         return localizer;
     }
 
-    /** Dagger component for crypto. */
+    /** Dagger component for {@link SiteVerifiedUserLocalizer}. */
     @Component(modules = {DemoSiteCryptoModule.class, TestDependenciesModule.class})
     @Singleton
-    interface TestComponent {
+    interface TestComponent extends Supplier<SiteVerifiedUserLocalizer> {
 
-        static TestComponent create() {
-            return DaggerDemoSiteVerifiedUserLocalizerTest_TestComponent.create();
+        static SiteVerifiedUserLocalizer create() {
+            return DaggerDemoSiteVerifiedUserLocalizerTest_TestComponent.create()
+                    .get();
         }
-
-        SiteVerifiedUserLocalizer verifiedUserLocalizer();
     }
 }

--- a/module/store-dynamodb/src/test/java/org/example/age/module/store/dynamodb/DynamoDbAvsAccountStoreTest.java
+++ b/module/store-dynamodb/src/test/java/org/example/age/module/store/dynamodb/DynamoDbAvsAccountStoreTest.java
@@ -2,6 +2,7 @@ package org.example.age.module.store.dynamodb;
 
 import dagger.Component;
 import jakarta.inject.Singleton;
+import java.util.function.Supplier;
 import org.example.age.api.testing.TestModels;
 import org.example.age.module.store.dynamodb.testing.DynamoDbTestContainer;
 import org.example.age.module.store.dynamodb.testing.TestDependenciesModule;
@@ -12,16 +13,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 public final class DynamoDbAvsAccountStoreTest extends AvsAccountStoreTestTemplate {
 
+    private static final AvsVerifiedUserStore store = TestComponent.create();
+
     @RegisterExtension
     private static final DynamoDbTestContainer dynamoDb = new DynamoDbTestContainer();
-
-    private static AvsVerifiedUserStore store;
-
-    @BeforeAll
-    public static void createAvsVerifiedUserStore() {
-        TestComponent component = TestComponent.create();
-        store = component.avsVerifiedUserStore();
-    }
 
     @BeforeAll
     public static void setUpContainer() {
@@ -34,15 +29,13 @@ public final class DynamoDbAvsAccountStoreTest extends AvsAccountStoreTestTempla
         return store;
     }
 
-    /** Dagger component for the store. */
+    /** Dagger component for {@link AvsVerifiedUserStore}. */
     @Component(modules = {DynamoDbAvsAccountStoreModule.class, TestDependenciesModule.class})
     @Singleton
-    interface TestComponent {
+    interface TestComponent extends Supplier<AvsVerifiedUserStore> {
 
-        static TestComponent create() {
-            return DaggerDynamoDbAvsAccountStoreTest_TestComponent.create();
+        static AvsVerifiedUserStore create() {
+            return DaggerDynamoDbAvsAccountStoreTest_TestComponent.create().get();
         }
-
-        AvsVerifiedUserStore avsVerifiedUserStore();
     }
 }

--- a/module/store-dynamodb/src/test/java/org/example/age/module/store/dynamodb/DynamoDbSiteAccountStoreTest.java
+++ b/module/store-dynamodb/src/test/java/org/example/age/module/store/dynamodb/DynamoDbSiteAccountStoreTest.java
@@ -2,6 +2,7 @@ package org.example.age.module.store.dynamodb;
 
 import dagger.Component;
 import jakarta.inject.Singleton;
+import java.util.function.Supplier;
 import org.example.age.module.store.dynamodb.testing.DynamoDbTestContainer;
 import org.example.age.module.store.dynamodb.testing.TestDependenciesModule;
 import org.example.age.service.module.store.SiteVerificationStore;
@@ -11,16 +12,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 public final class DynamoDbSiteAccountStoreTest extends SiteAccountStoreTestTemplate {
 
+    private static final SiteVerificationStore store = TestComponent.create();
+
     @RegisterExtension
     private static final DynamoDbTestContainer dynamoDb = new DynamoDbTestContainer();
-
-    private static SiteVerificationStore store;
-
-    @BeforeAll
-    public static void createSiteVerificationStore() {
-        TestComponent component = TestComponent.create();
-        store = component.siteVerificationStore();
-    }
 
     @BeforeAll
     public static void setUpContainer() {
@@ -32,15 +27,13 @@ public final class DynamoDbSiteAccountStoreTest extends SiteAccountStoreTestTemp
         return store;
     }
 
-    /** Dagger component for the store. */
+    /** Dagger component for {@link SiteVerificationStore} */
     @Component(modules = {DynamoDbSiteAccountStoreModule.class, TestDependenciesModule.class})
     @Singleton
-    interface TestComponent {
+    interface TestComponent extends Supplier<SiteVerificationStore> {
 
-        static TestComponent create() {
-            return DaggerDynamoDbSiteAccountStoreTest_TestComponent.create();
+        static SiteVerificationStore create() {
+            return DaggerDynamoDbSiteAccountStoreTest_TestComponent.create().get();
         }
-
-        SiteVerificationStore siteVerificationStore();
     }
 }

--- a/module/store-dynamodb/src/test/java/org/example/age/module/store/dynamodb/client/DynamoDbClientTest.java
+++ b/module/store-dynamodb/src/test/java/org/example/age/module/store/dynamodb/client/DynamoDbClientTest.java
@@ -2,9 +2,9 @@ package org.example.age.module.store.dynamodb.client;
 
 import dagger.Component;
 import jakarta.inject.Singleton;
+import java.util.function.Supplier;
 import org.example.age.module.store.dynamodb.testing.DynamoDbTestContainer;
 import org.example.age.module.store.dynamodb.testing.TestDependenciesModule;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -17,16 +17,10 @@ import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 
 public final class DynamoDbClientTest {
 
+    private static final DynamoDbClient client = TestComponent.create();
+
     @RegisterExtension
     private static final DynamoDbTestContainer dynamoDb = new DynamoDbTestContainer();
-
-    private static DynamoDbClient client;
-
-    @BeforeAll
-    public static void createClient() {
-        TestComponent component = TestComponent.create();
-        client = component.dynamoDbClient();
-    }
 
     @Test
     public void useClient() {
@@ -46,15 +40,13 @@ public final class DynamoDbClientTest {
         client.waiter().waitUntilTableExists(builder -> builder.tableName("table"));
     }
 
-    /** Dagger component for the client. */
+    /** Dagger component for {@link DynamoDbClient} */
     @Component(modules = {DynamoDbClientModule.class, TestDependenciesModule.class})
     @Singleton
-    interface TestComponent {
+    interface TestComponent extends Supplier<DynamoDbClient> {
 
-        static TestComponent create() {
-            return DaggerDynamoDbClientTest_TestComponent.create();
+        static DynamoDbClient create() {
+            return DaggerDynamoDbClientTest_TestComponent.create().get();
         }
-
-        DynamoDbClient dynamoDbClient();
     }
 }

--- a/module/store-dynamodb/src/test/java/org/example/age/module/store/dynamodb/testing/TestConfig.java
+++ b/module/store-dynamodb/src/test/java/org/example/age/module/store/dynamodb/testing/TestConfig.java
@@ -9,7 +9,7 @@ public final class TestConfig {
 
     private static final DynamoDbConfig dynamoDb = DynamoDbConfig.builder()
             .region(Region.US_EAST_1.toString())
-            .testEndpointOverride(TestClient.createLocalhostUri(DynamoDbTestContainer.PORT))
+            .testEndpointOverride(TestClient.localhostUri(DynamoDbTestContainer.PORT))
             .build();
 
     /** Gets the configuration for DynamoDB. */

--- a/module/store-dynamodb/src/testFixtures/java/org/example/age/module/store/dynamodb/testing/DynamoDbTestContainer.java
+++ b/module/store-dynamodb/src/testFixtures/java/org/example/age/module/store/dynamodb/testing/DynamoDbTestContainer.java
@@ -72,7 +72,7 @@ public final class DynamoDbTestContainer extends BaseTestContainer<DynamoDbClien
     protected DynamoDbClient createClient() {
         return DynamoDbClient.builder()
                 .region(Region.US_EAST_1)
-                .endpointOverride(TestClient.createLocalhostUri(PORT))
+                .endpointOverride(TestClient.localhostUri(PORT))
                 .credentialsProvider(
                         StaticCredentialsProvider.create(AwsBasicCredentials.create("dummyKey", "dummySecret")))
                 .build();

--- a/module/store-redis/src/test/java/org/example/age/module/store/redis/RedisAvsAccountStoreTest.java
+++ b/module/store-redis/src/test/java/org/example/age/module/store/redis/RedisAvsAccountStoreTest.java
@@ -2,6 +2,7 @@ package org.example.age.module.store.redis;
 
 import dagger.Component;
 import jakarta.inject.Singleton;
+import java.util.function.Supplier;
 import org.example.age.api.testing.TestModels;
 import org.example.age.module.store.redis.testing.RedisTestContainer;
 import org.example.age.module.store.redis.testing.TestDependenciesModule;
@@ -12,16 +13,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 public final class RedisAvsAccountStoreTest extends AvsAccountStoreTestTemplate {
 
+    private static final AvsVerifiedUserStore store = TestComponent.create();
+
     @RegisterExtension
     private static final RedisTestContainer redis = new RedisTestContainer();
-
-    private static AvsVerifiedUserStore store;
-
-    @BeforeAll
-    public static void createAvsVerifiedUserStore() {
-        TestComponent component = TestComponent.create();
-        store = component.avsVerifiedUserStore();
-    }
 
     @BeforeAll
     public static void setUpContainer() {
@@ -33,15 +28,13 @@ public final class RedisAvsAccountStoreTest extends AvsAccountStoreTestTemplate 
         return store;
     }
 
-    /** Dagger component for the store. */
+    /** Dagger component for {@link AvsVerifiedUserStore}. */
     @Component(modules = {RedisAvsAccountStoreModule.class, TestDependenciesModule.class})
     @Singleton
-    interface TestComponent {
+    interface TestComponent extends Supplier<AvsVerifiedUserStore> {
 
-        static TestComponent create() {
-            return DaggerRedisAvsAccountStoreTest_TestComponent.create();
+        static AvsVerifiedUserStore create() {
+            return DaggerRedisAvsAccountStoreTest_TestComponent.create().get();
         }
-
-        AvsVerifiedUserStore avsVerifiedUserStore();
     }
 }

--- a/module/store-redis/src/test/java/org/example/age/module/store/redis/RedisPendingStoreTest.java
+++ b/module/store-redis/src/test/java/org/example/age/module/store/redis/RedisPendingStoreTest.java
@@ -5,28 +5,22 @@ import static org.example.age.common.testing.WebStageTesting.await;
 
 import dagger.Component;
 import jakarta.inject.Singleton;
+import java.util.function.Supplier;
 import org.example.age.module.store.redis.testing.RedisTestContainer;
 import org.example.age.module.store.redis.testing.TestDependenciesModule;
 import org.example.age.service.module.store.PendingStore;
 import org.example.age.service.module.store.PendingStoreRepository;
 import org.example.age.service.module.store.testing.PendingStoreTestTemplate;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import redis.clients.jedis.JedisPooled;
 
 public final class RedisPendingStoreTest extends PendingStoreTestTemplate {
 
+    private static final PendingStoreRepository stores = TestComponent.create();
+
     @RegisterExtension
     private static final RedisTestContainer redis = new RedisTestContainer();
-
-    private static PendingStoreRepository stores;
-
-    @BeforeAll
-    public static void createPendingStoreRepository() {
-        TestComponent component = TestComponent.create();
-        stores = component.pendingStoreRepository();
-    }
 
     @Test
     public void redisKeys() {
@@ -42,15 +36,13 @@ public final class RedisPendingStoreTest extends PendingStoreTestTemplate {
         return stores.get("name", Integer.class);
     }
 
-    /** Dagger component for the store. */
+    /** Dagger component for {@link PendingStoreRepository}. */
     @Component(modules = {RedisPendingStoreModule.class, TestDependenciesModule.class})
     @Singleton
-    interface TestComponent {
+    interface TestComponent extends Supplier<PendingStoreRepository> {
 
-        static TestComponent create() {
-            return DaggerRedisPendingStoreTest_TestComponent.create();
+        static PendingStoreRepository create() {
+            return DaggerRedisPendingStoreTest_TestComponent.create().get();
         }
-
-        PendingStoreRepository pendingStoreRepository();
     }
 }

--- a/module/store-redis/src/test/java/org/example/age/module/store/redis/RedisSiteAccountStoreTest.java
+++ b/module/store-redis/src/test/java/org/example/age/module/store/redis/RedisSiteAccountStoreTest.java
@@ -6,29 +6,23 @@ import static org.example.age.common.testing.WebStageTesting.await;
 import dagger.Component;
 import jakarta.inject.Singleton;
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.example.age.api.VerifiedUser;
 import org.example.age.api.testing.TestModels;
 import org.example.age.module.store.redis.testing.RedisTestContainer;
 import org.example.age.module.store.redis.testing.TestDependenciesModule;
 import org.example.age.service.module.store.SiteVerificationStore;
 import org.example.age.service.module.store.testing.SiteAccountStoreTestTemplate;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import redis.clients.jedis.JedisPooled;
 
 public final class RedisSiteAccountStoreTest extends SiteAccountStoreTestTemplate {
 
+    private static final SiteVerificationStore store = TestComponent.create();
+
     @RegisterExtension
     private static final RedisTestContainer redis = new RedisTestContainer();
-
-    private static SiteVerificationStore store;
-
-    @BeforeAll
-    public static void createSiteVerificationStore() {
-        TestComponent component = TestComponent.create();
-        store = component.siteVerificationStore();
-    }
 
     @Test
     public void redisKeys() {
@@ -51,15 +45,13 @@ public final class RedisSiteAccountStoreTest extends SiteAccountStoreTestTemplat
         return store;
     }
 
-    /** Dagger component for the store. */
+    /** Dagger component for {@link SiteVerificationStore}. */
     @Component(modules = {RedisSiteAccountStoreModule.class, TestDependenciesModule.class})
     @Singleton
-    interface TestComponent {
+    interface TestComponent extends Supplier<SiteVerificationStore> {
 
-        static TestComponent create() {
-            return DaggerRedisSiteAccountStoreTest_TestComponent.create();
+        static SiteVerificationStore create() {
+            return DaggerRedisSiteAccountStoreTest_TestComponent.create().get();
         }
-
-        SiteVerificationStore siteVerificationStore();
     }
 }

--- a/module/store-redis/src/test/java/org/example/age/module/store/redis/client/RedisClientTest.java
+++ b/module/store-redis/src/test/java/org/example/age/module/store/redis/client/RedisClientTest.java
@@ -4,25 +4,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dagger.Component;
 import jakarta.inject.Singleton;
+import java.util.function.Supplier;
 import org.example.age.module.store.redis.testing.RedisTestContainer;
 import org.example.age.module.store.redis.testing.TestDependenciesModule;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import redis.clients.jedis.JedisPooled;
 
 public final class RedisClientTest {
 
+    private static final JedisPooled client = TestComponent.create();
+
     @RegisterExtension
     private static final RedisTestContainer redis = new RedisTestContainer();
-
-    private static JedisPooled client;
-
-    @BeforeAll
-    public static void createClient() {
-        TestComponent component = TestComponent.create();
-        client = component.jedisPooled();
-    }
 
     @Test
     public void useClient() {
@@ -31,15 +25,13 @@ public final class RedisClientTest {
         assertThat(value).isEqualTo("value");
     }
 
-    /** Dagger component for the client. */
+    /** Dagger component for {@link JedisPooled}. */
     @Component(modules = {RedisClientModule.class, TestDependenciesModule.class})
     @Singleton
-    interface TestComponent {
+    interface TestComponent extends Supplier<JedisPooled> {
 
-        static TestComponent create() {
-            return DaggerRedisClientTest_TestComponent.create();
+        static JedisPooled create() {
+            return DaggerRedisClientTest_TestComponent.create().get();
         }
-
-        JedisPooled jedisPooled();
     }
 }

--- a/module/store-redis/src/test/java/org/example/age/module/store/redis/testing/TestConfig.java
+++ b/module/store-redis/src/test/java/org/example/age/module/store/redis/testing/TestConfig.java
@@ -7,7 +7,7 @@ import org.example.age.module.store.redis.client.RedisConfig;
 public final class TestConfig {
 
     private static final RedisConfig redis = RedisConfig.builder()
-            .url(TestClient.createLocalhostUrl(RedisTestContainer.PORT))
+            .url(TestClient.localhostUrl(RedisTestContainer.PORT))
             .build();
 
     /** Gets the configuration for Redis. */

--- a/module/store-redis/src/testFixtures/java/org/example/age/module/store/redis/testing/RedisTestContainer.java
+++ b/module/store-redis/src/testFixtures/java/org/example/age/module/store/redis/testing/RedisTestContainer.java
@@ -19,7 +19,7 @@ public final class RedisTestContainer extends BaseTestContainer<JedisPooled> {
 
     @Override
     protected JedisPooled createClient() {
-        return new JedisPooled(TestClient.createLocalhostUri(PORT));
+        return new JedisPooled(TestClient.localhostUri(PORT));
     }
 
     @Override

--- a/service/module/src/testFixtures/java/org/example/age/service/module/request/testing/AccountIdTestTemplate.java
+++ b/service/module/src/testFixtures/java/org/example/age/service/module/request/testing/AccountIdTestTemplate.java
@@ -17,10 +17,10 @@ public abstract class AccountIdTestTemplate {
 
     @Test
     public void accountId() throws IOException {
-        Request.Builder requestBuilder = new Request.Builder().url(TestClient.createLocalhostUrl(port()));
+        Request.Builder requestBuilder = new Request.Builder().url(TestClient.localhostUrl(port()));
         setAccountId(requestBuilder, "username");
         Request request = requestBuilder.build();
-        try (Response response = TestClient.getHttp().newCall(request).execute()) {
+        try (Response response = TestClient.http().newCall(request).execute()) {
             assertThat(response.isSuccessful()).isTrue();
             assertThat(response.body().string()).isEqualTo("username");
         }
@@ -29,8 +29,8 @@ public abstract class AccountIdTestTemplate {
     @Test
     public void noAccountId() throws IOException {
         Request request =
-                new Request.Builder().url(TestClient.createLocalhostUrl(port())).build();
-        try (Response response = TestClient.getHttp().newCall(request).execute()) {
+                new Request.Builder().url(TestClient.localhostUrl(port())).build();
+        try (Response response = TestClient.http().newCall(request).execute()) {
             assertThat(response.code()).isEqualTo(401);
         }
     }
@@ -42,13 +42,7 @@ public abstract class AccountIdTestTemplate {
     /** Test service that responds with the account ID. */
     @Path("")
     @Produces(MediaType.TEXT_PLAIN)
-    public static final class TestService {
-
-        private final AccountIdContext accountIdContext;
-
-        public TestService(AccountIdContext accountIdContext) {
-            this.accountIdContext = accountIdContext;
-        }
+    public record TestService(AccountIdContext accountIdContext) {
 
         @GET
         public String accountId() {


### PR DESCRIPTION
- directly initialize test fields that are created via components
- simplify component creation for singleton test components
- use records to build test services
- shorten method names in `TestClient`