### PR TITLE
simplify LiteEnv

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     api(libs.bundles.dropwizard)
     api(libs.bundles.json)
     implementation(project(":module:request-demo"))
+    implementation(project(":module:common"))
     implementation(libs.bundles.dynamoDb) // for Dagger
     implementation(libs.bundles.redis) // for Dagger
 

--- a/app/src/main/java/org/example/age/app/AvsApp.java
+++ b/app/src/main/java/org/example/age/app/AvsApp.java
@@ -9,8 +9,8 @@ import jakarta.inject.Singleton;
 import org.example.age.api.AvsApi;
 import org.example.age.app.config.AvsAppConfig;
 import org.example.age.app.config.AvsConfigModule;
-import org.example.age.app.env.EnvModule;
 import org.example.age.module.client.AvsClientModule;
+import org.example.age.module.common.LiteEnvModule;
 import org.example.age.module.crypto.demo.DemoAvsCryptoModule;
 import org.example.age.module.request.demo.DemoAccountIdModule;
 import org.example.age.module.store.dynamodb.DynamoDbAvsAccountStoreModule;
@@ -53,7 +53,7 @@ public class AvsApp extends Application<AvsAppConfig> {
                 RedisPendingStoreModule.class,
                 DemoAvsCryptoModule.class,
                 AvsConfigModule.class,
-                EnvModule.class,
+                LiteEnvModule.class,
             })
     @Singleton
     interface AppComponent {

--- a/app/src/main/java/org/example/age/app/SiteApp.java
+++ b/app/src/main/java/org/example/age/app/SiteApp.java
@@ -9,8 +9,8 @@ import jakarta.inject.Singleton;
 import org.example.age.api.SiteApi;
 import org.example.age.app.config.SiteAppConfig;
 import org.example.age.app.config.SiteConfigModule;
-import org.example.age.app.env.EnvModule;
 import org.example.age.module.client.SiteClientModule;
+import org.example.age.module.common.LiteEnvModule;
 import org.example.age.module.crypto.demo.DemoSiteCryptoModule;
 import org.example.age.module.request.demo.DemoAccountIdModule;
 import org.example.age.module.store.dynamodb.DynamoDbSiteAccountStoreModule;
@@ -53,7 +53,7 @@ public final class SiteApp extends Application<SiteAppConfig> {
                 RedisPendingStoreModule.class,
                 DemoSiteCryptoModule.class,
                 SiteConfigModule.class,
-                EnvModule.class,
+                LiteEnvModule.class,
             })
     @Singleton
     interface AppComponent {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,7 +51,7 @@ Gradle is the build system. The code is split into multiple Gradle modules (e.g.
 - Implementations of the JAX-RS interfaces can be found in `:service`.
 - Implementations of the interfaces in `:service:module` can be found in `:module:*` (e.g., `:module:store-redis`).
     - Many modules come with configuration, which is defined via Immutables + Jackson.
-    - Modules depend on [`LiteEnv`](/module/common/src/main/java/org/example/age/module/common/LiteEnv.java), a lightweight facade for the Dropwizard `Environment`.
+    - Many modules depend on [`LiteEnv`](/module/common/src/main/java/org/example/age/module/common/LiteEnv.java), a lightweight facade for the Dropwizard `Environment`.
 - Since this is a proof-of-concept, some modules in `:module:*` have "demo" implementations.
 
 **Web Applications**
@@ -59,7 +59,7 @@ Gradle is the build system. The code is split into multiple Gradle modules (e.g.
 - The web applications can be found in `:app`.
 - A Dropwizard app only needs to implement one method: `void run(T configuration, Environment environment)`.
     - The configuration class (`T extends Configuration`) is a [container](/app/src/main/java/org/example/age/app/config/SiteAppConfig.java) for all the module-specific configuration.
-    - An [implementation](/app/src/main/java/org/example/age/app/env/DropwizardLiteEnv.java) of the `LiteEnv` facade is provided using the Dropwizard `Environment`.
+    - An [implementation](/module/common/src/main/java/org/example/age/module/common/DropwizardLiteEnv.java) of the `LiteEnv` facade is provided using the Dropwizard `Environment`.
 - Since a proof-of-concept is not deployed to production, ops features are excluded: health checks, metrics, logging, etc.
 
 ### Testability
@@ -120,7 +120,7 @@ Most of the test coverage comes from unit tests.
     - To inject an instance of the class for each request, a Dropwizard app would call `register(Class<?>)`; this uses HK2.
 - We cannot add a `@Context HttpHeaders` arg to the JAX-RS interface; this interface is generated from the OpenAPI YAML file.
 
-**Solution:** Use Jersey/HK2 to inject a `Provider<HttpHeaders>` via a `ContainerLifecyleListener`. See: [`JerseyRequestContext`](/module/common/src/main/java/org/example/age/module/common/JerseyRequestContext.java)
+**Solution:** Use HK2 to inject a `Provider<HttpHeaders>` via a `ContainerLifecycleListener`. See: [`DropwizardRequestContext`](/module/common/src/main/java/org/example/age/module/common/DropwizardRequestContext.java)
 
 - **Downside:** This provider only works if you call `get()` in the thread that handles the HTTP request.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,6 @@ immutables-value = { module = "org.immutables:value", version.ref = "immutables"
 awsSdk-dynamoDb = { module = "software.amazon.awssdk:dynamodb", version.ref = "awsSdk" }
 dagger-dagger = { module = "com.google.dagger:dagger", version.ref = "dagger" }
 dropwizard-core = { module = "io.dropwizard:dropwizard-core", version.ref = "dropwizard" }
-dropwizard-jersey = { module = "io.dropwizard:dropwizard-jersey", version.ref = "dropwizard" }
 jedis-jedis = { module = "redis.clients:jedis", version.ref = "jedis" }
 immutables-annotations = { module = "org.immutables:value-annotations", version.ref = "immutables" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
@@ -54,6 +53,7 @@ retrofit-retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = 
 # test
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 dropwizard-jackson = { module = "io.dropwizard:dropwizard-jackson", version.ref = "dropwizard" }
+dropwizard-jersey = { module = "io.dropwizard:dropwizard-jersey", version.ref = "dropwizard" }
 dropwizard-testing = { module = "io.dropwizard:dropwizard-testing", version.ref = "dropwizard" }
 guava-testlib = { module = "com.google.guava:guava-testlib", version.ref = "guava" }
 junitJupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junitJupiter" }

--- a/module/common/build.gradle.kts
+++ b/module/common/build.gradle.kts
@@ -7,16 +7,16 @@ plugins {
 dependencies {
     annotationProcessor(libs.dagger.compiler)
 
-    api(libs.bundles.dagger)
     api(libs.bundles.jaxRs)
     api(libs.bundles.json)
-    implementation(libs.dropwizard.jersey)
+    implementation(libs.bundles.dagger)
+    implementation(libs.bundles.dropwizard)
 
     testFixturesAnnotationProcessor(libs.dagger.compiler)
 
-    testFixturesApi(libs.bundles.dagger)
     testFixturesApi(libs.junitJupiter.api)
     testFixturesImplementation(testFixtures(project(":common")))
+    testFixturesImplementation(libs.bundles.dagger)
     testFixturesImplementation(libs.bundles.json)
 
     testAnnotationProcessor(libs.dagger.compiler)

--- a/module/common/src/main/java/org/example/age/module/common/CommonModule.java
+++ b/module/common/src/main/java/org/example/age/module/common/CommonModule.java
@@ -6,7 +6,6 @@ import dagger.Module;
 /**
  * Dagger module that binds...
  * <ul>
- *     <li>{@link RequestContext}
  *     <li>{@link JsonMapper}
  *     <li>{@link Worker}
  * </ul>
@@ -15,9 +14,6 @@ import dagger.Module;
  */
 @Module
 public interface CommonModule {
-
-    @Binds
-    RequestContext bindRequestContext(JerseyRequestContext impl);
 
     @Binds
     JsonMapper bindJsonMapper(JsonMapperImpl impl);

--- a/module/common/src/main/java/org/example/age/module/common/DropwizardLiteEnv.java
+++ b/module/common/src/main/java/org/example/age/module/common/DropwizardLiteEnv.java
@@ -1,13 +1,11 @@
-package org.example.age.app.env;
+package org.example.age.module.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.core.setup.Environment;
-import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.util.Duration;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.concurrent.ExecutorService;
-import org.example.age.module.common.LiteEnv;
 
 /** Implementation of {@link LiteEnv} for Dropwizard. */
 @Singleton
@@ -15,13 +13,11 @@ final class DropwizardLiteEnv implements LiteEnv {
 
     private final ObjectMapper mapper;
     private final ExecutorService worker;
-    private final JerseyEnvironment jersey;
 
     @Inject
     public DropwizardLiteEnv(Environment env) {
         mapper = env.getObjectMapper();
         worker = createWorker(env);
-        jersey = env.jersey();
     }
 
     @Override
@@ -32,11 +28,6 @@ final class DropwizardLiteEnv implements LiteEnv {
     @Override
     public ExecutorService worker() {
         return worker;
-    }
-
-    @Override
-    public void register(Object component) {
-        jersey.register(component);
     }
 
     /** Creates the thread pool for the worker. */

--- a/module/common/src/main/java/org/example/age/module/common/DropwizardRequestContext.java
+++ b/module/common/src/main/java/org/example/age/module/common/DropwizardRequestContext.java
@@ -1,5 +1,6 @@
 package org.example.age.module.common;
 
+import io.dropwizard.core.setup.Environment;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
@@ -10,15 +11,15 @@ import org.glassfish.jersey.internal.inject.InjectionManager;
 import org.glassfish.jersey.server.spi.Container;
 import org.glassfish.jersey.server.spi.ContainerLifecycleListener;
 
-/** Implementation of {@link RequestContext} that uses Jersey/HK2. */
+/** Implementation of {@link RequestContext} for Dropwizard. */
 @Singleton
-final class JerseyRequestContext implements RequestContext {
+final class DropwizardRequestContext implements RequestContext {
 
     private Provider<HttpHeaders> httpHeadersProvider;
 
     @Inject
-    public JerseyRequestContext(LiteEnv liteEnv) {
-        liteEnv.register(new RequestContextInjector());
+    public DropwizardRequestContext(Environment env) {
+        env.jersey().register(new RequestContextInjector());
     }
 
     @Override

--- a/module/common/src/main/java/org/example/age/module/common/LiteEnv.java
+++ b/module/common/src/main/java/org/example/age/module/common/LiteEnv.java
@@ -11,7 +11,4 @@ public interface LiteEnv {
 
     /** Gets the worker thread pool. */
     ExecutorService worker();
-
-    /** Registers a component with Jersey. */
-    void register(Object component);
 }

--- a/module/common/src/main/java/org/example/age/module/common/LiteEnvModule.java
+++ b/module/common/src/main/java/org/example/age/module/common/LiteEnvModule.java
@@ -1,9 +1,8 @@
-package org.example.age.app.env;
+package org.example.age.module.common;
 
 import dagger.Binds;
 import dagger.Module;
 import io.dropwizard.core.setup.Environment;
-import org.example.age.module.common.LiteEnv;
 
 /**
  * Dagger module that binds {@link LiteEnv}.
@@ -11,7 +10,7 @@ import org.example.age.module.common.LiteEnv;
  * Depends on an unbound {@link Environment}.
  */
 @Module
-public interface EnvModule {
+public interface LiteEnvModule {
 
     @Binds
     LiteEnv bindLiteEnv(DropwizardLiteEnv impl);

--- a/module/common/src/main/java/org/example/age/module/common/RequestModule.java
+++ b/module/common/src/main/java/org/example/age/module/common/RequestModule.java
@@ -1,0 +1,17 @@
+package org.example.age.module.common;
+
+import dagger.Binds;
+import dagger.Module;
+import io.dropwizard.core.setup.Environment;
+
+/**
+ * Dagger module that binds {@link RequestContext}.
+ * <p>
+ * Depends on an unbound {@link Environment}.
+ */
+@Module
+public interface RequestModule {
+
+    @Binds
+    RequestContext bindRequestContext(DropwizardRequestContext impl);
+}

--- a/module/common/src/test/java/org/example/age/module/common/RequestTest.java
+++ b/module/common/src/test/java/org/example/age/module/common/RequestTest.java
@@ -18,8 +18,6 @@ import java.util.function.Supplier;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.example.age.common.testing.TestClient;
-import org.example.age.module.common.testing.TestComponentRegistrar;
-import org.example.age.module.common.testing.TestLiteEnvModule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -62,20 +60,18 @@ public final class RequestTest {
         }
     }
 
-    @Component(modules = {CommonModule.class, TestLiteEnvModule.class})
+    @Component(modules = RequestModule.class)
     @Singleton
     interface TestComponent extends Supplier<RequestContext> {
 
         static RequestContext create(Environment env) {
-            return DaggerRequestTest_TestComponent.factory()
-                    .create(component -> env.jersey().register(component))
-                    .get();
+            return DaggerRequestTest_TestComponent.factory().create(env).get();
         }
 
         @Component.Factory
         interface Factory {
 
-            TestComponent create(@BindsInstance TestComponentRegistrar componentRegistrar);
+            TestComponent create(@BindsInstance Environment env);
         }
     }
 }

--- a/module/common/src/testFixtures/java/org/example/age/module/common/testing/TestComponentRegistrar.java
+++ b/module/common/src/testFixtures/java/org/example/age/module/common/testing/TestComponentRegistrar.java
@@ -1,8 +1,0 @@
-package org.example.age.module.common.testing;
-
-/** Registers a component with Jersey. */
-@FunctionalInterface
-public interface TestComponentRegistrar {
-
-    void register(Object component);
-}

--- a/module/common/src/testFixtures/java/org/example/age/module/common/testing/TestLiteEnv.java
+++ b/module/common/src/testFixtures/java/org/example/age/module/common/testing/TestLiteEnv.java
@@ -3,7 +3,6 @@ package org.example.age.module.common.testing;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.example.age.common.testing.TestObjectMapper;
@@ -14,12 +13,9 @@ import org.example.age.module.common.LiteEnv;
 final class TestLiteEnv implements LiteEnv {
 
     private final ExecutorService worker = Executors.newFixedThreadPool(1);
-    private final TestComponentRegistrar componentRegistrar;
 
     @Inject
-    public TestLiteEnv(Optional<TestComponentRegistrar> maybeComponentRegistrar) {
-        componentRegistrar = maybeComponentRegistrar.orElse(component -> {});
-    }
+    public TestLiteEnv() {}
 
     @Override
     public ObjectMapper jsonMapper() {
@@ -29,10 +25,5 @@ final class TestLiteEnv implements LiteEnv {
     @Override
     public ExecutorService worker() {
         return worker;
-    }
-
-    @Override
-    public void register(Object component) {
-        componentRegistrar.register(component);
     }
 }

--- a/module/common/src/testFixtures/java/org/example/age/module/common/testing/TestLiteEnvModule.java
+++ b/module/common/src/testFixtures/java/org/example/age/module/common/testing/TestLiteEnvModule.java
@@ -1,14 +1,11 @@
 package org.example.age.module.common.testing;
 
 import dagger.Binds;
-import dagger.BindsOptionalOf;
 import dagger.Module;
 import org.example.age.module.common.LiteEnv;
 
 /**
  * Dagger module that binds {@link LiteEnv}.
- * <p>
- * Depends on an unbound optional {@link TestComponentRegistrar}.
  * <p>
  * The worker has a single thread.
  */
@@ -17,7 +14,4 @@ public interface TestLiteEnvModule {
 
     @Binds
     LiteEnv bindLiteEnv(TestLiteEnv impl);
-
-    @BindsOptionalOf
-    TestComponentRegistrar bindOptionalTestComponentRegistrar();
 }

--- a/module/request-demo/build.gradle.kts
+++ b/module/request-demo/build.gradle.kts
@@ -6,16 +6,15 @@ plugins {
 dependencies {
     annotationProcessor(libs.dagger.compiler)
 
-    api(project(":service:module"))
-    api(project(":module:common"))
-    api(libs.bundles.dagger)
+    implementation(project(":service:module"))
+    implementation(project(":module:common"))
+    implementation(libs.bundles.dagger)
     implementation(libs.bundles.jaxRs)
 
     testAnnotationProcessor(libs.dagger.compiler)
 
     testImplementation(testFixtures(project(":common")))
     testImplementation(testFixtures(project(":service:module")))
-    testImplementation(testFixtures(project(":module:common")))
     testImplementation(libs.bundles.dropwizard)
     testImplementation(libs.bundles.retrofit)
     testImplementation(libs.dropwizard.testing)

--- a/module/request-demo/src/main/java/org/example/age/module/request/demo/DemoAccountIdModule.java
+++ b/module/request-demo/src/main/java/org/example/age/module/request/demo/DemoAccountIdModule.java
@@ -2,18 +2,17 @@ package org.example.age.module.request.demo;
 
 import dagger.Binds;
 import dagger.Module;
-import org.example.age.module.common.CommonModule;
-import org.example.age.module.common.LiteEnv;
+import org.example.age.module.common.RequestModule;
 import org.example.age.service.module.request.AccountIdContext;
 
 /**
  * Dagger module that binds {@link AccountIdContext}.
  * <p>
- * Depends on an unbound {@link LiteEnv}.
+ * Depends on an unbound {@code Environment}.
  * <p>
  * Uses an {@code Account-Id} header; it suffices to say that a production application should NOT do this.
  */
-@Module(includes = CommonModule.class)
+@Module(includes = RequestModule.class)
 public interface DemoAccountIdModule {
 
     @Binds

--- a/module/request-demo/src/test/java/org/example/age/module/request/demo/DemoAccountIdTest.java
+++ b/module/request-demo/src/test/java/org/example/age/module/request/demo/DemoAccountIdTest.java
@@ -9,8 +9,6 @@ import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import jakarta.inject.Singleton;
 import java.util.function.Supplier;
 import okhttp3.Request;
-import org.example.age.module.common.testing.TestComponentRegistrar;
-import org.example.age.module.common.testing.TestLiteEnvModule;
 import org.example.age.service.module.request.AccountIdContext;
 import org.example.age.service.module.request.testing.AccountIdTestTemplate;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -42,20 +40,18 @@ public final class DemoAccountIdTest extends AccountIdTestTemplate {
     }
 
     /** Dagger component for {@link AccountIdContext}. */
-    @Component(modules = {DemoAccountIdModule.class, TestLiteEnvModule.class})
+    @Component(modules = DemoAccountIdModule.class)
     @Singleton
     interface TestComponent extends Supplier<AccountIdContext> {
 
         static AccountIdContext create(Environment env) {
-            return DaggerDemoAccountIdTest_TestComponent.factory()
-                    .create(component -> env.jersey().register(component))
-                    .get();
+            return DaggerDemoAccountIdTest_TestComponent.factory().create(env).get();
         }
 
         @Component.Factory
         interface Factory {
 
-            TestComponent create(@BindsInstance TestComponentRegistrar componentRegistrar);
+            TestComponent create(@BindsInstance Environment env);
         }
     }
 }


### PR DESCRIPTION
- request context directly depends on `Environment`
- `register()` removed from `LiteEnv`
- also move Dropwizard impl into `:module:common`