### PR TITLE
refactor common JSON test utils

### DIFF
--- a/common/src/test/java/org/example/age/common/testing/JsonTestingTest.java
+++ b/common/src/test/java/org/example/age/common/testing/JsonTestingTest.java
@@ -1,6 +1,5 @@
 package org.example.age.common.testing;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -11,7 +10,7 @@ import org.junit.jupiter.api.Test;
 public final class JsonTestingTest {
 
     @Test
-    public void serializeThenDeserialize_String() throws IOException {
+    public void serializeThenDeserialize() throws IOException {
         JsonTesting.serializeThenDeserialize("test", String.class);
     }
 
@@ -19,13 +18,6 @@ public final class JsonTestingTest {
     public void serializeThenDeserialize_BadValue() {
         assertThatThrownBy(() -> JsonTesting.serializeThenDeserialize(BadValue.fromString("value"), BadValue.class))
                 .isInstanceOf(AssertionError.class);
-    }
-
-    @Test
-    public void serializeThenDeserialize_TestUtils() {
-        String json = JsonTesting.serialize("test");
-        String value = JsonTesting.deserialize(json, String.class);
-        assertThat(value).isEqualTo("test");
     }
 
     /** Value type that serializes incorrectly. */

--- a/common/src/test/java/org/example/age/common/testing/TestObjectMapperTest.java
+++ b/common/src/test/java/org/example/age/common/testing/TestObjectMapperTest.java
@@ -13,4 +13,11 @@ public final class TestObjectMapperTest {
         assertThat(mapper).isNotNull();
         assertThat(mapper).isSameAs(TestObjectMapper.get());
     }
+
+    @Test
+    public void serializeThenDeserialize() {
+        String json = TestObjectMapper.serialize("test");
+        String value = TestObjectMapper.deserialize(json, String.class);
+        assertThat(value).isEqualTo("test");
+    }
 }

--- a/common/src/testFixtures/java/org/example/age/common/testing/JsonTesting.java
+++ b/common/src/testFixtures/java/org/example/age/common/testing/JsonTesting.java
@@ -9,37 +9,9 @@ public final class JsonTesting {
 
     /** Serializes then deserializes an object, asserting that the deserialized object equals the original object. */
     public static <V> void serializeThenDeserialize(V value, Class<V> valueType) throws IOException {
-        String json = serializeInternal(value);
-        V rtValue = deserializeInternal(json, valueType);
+        String json = TestObjectMapper.get().writeValueAsString(value);
+        V rtValue = TestObjectMapper.deserialize(json, valueType);
         assertThat(rtValue).isEqualTo(value);
-    }
-
-    /** Serializes an object to JSON. */
-    public static String serialize(Object value) {
-        try {
-            return serializeInternal(value);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /** Deserializes an object from JSON. */
-    public static <V> V deserialize(String json, Class<V> valueType) {
-        try {
-            return deserializeInternal(json, valueType);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /** Serializes an object to JSON. */
-    private static String serializeInternal(Object value) throws IOException {
-        return TestObjectMapper.get().writeValueAsString(value);
-    }
-
-    /** Deserializes an object from JSON. */
-    private static <V> V deserializeInternal(String json, Class<V> valueType) throws IOException {
-        return TestObjectMapper.get().readValue(json, valueType);
     }
 
     private JsonTesting() {} // static class

--- a/common/src/testFixtures/java/org/example/age/common/testing/TestObjectMapper.java
+++ b/common/src/testFixtures/java/org/example/age/common/testing/TestObjectMapper.java
@@ -2,6 +2,7 @@ package org.example.age.common.testing;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
+import java.io.IOException;
 
 /** Singleton JSON object mapper for testing. */
 public final class TestObjectMapper {
@@ -11,6 +12,34 @@ public final class TestObjectMapper {
     /** Gets the JSON object mapper. */
     public static ObjectMapper get() {
         return mapper;
+    }
+
+    /** Serializes an object to JSON. */
+    public static String serialize(Object value) {
+        try {
+            return serializeInternal(value);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Deserializes an object from JSON. */
+    public static <V> V deserialize(String json, Class<V> valueType) {
+        try {
+            return deserializeInternal(json, valueType);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Serializes an object to JSON. */
+    private static String serializeInternal(Object value) throws IOException {
+        return TestObjectMapper.get().writeValueAsString(value);
+    }
+
+    /** Deserializes an object from JSON. */
+    private static <V> V deserializeInternal(String json, Class<V> valueType) throws IOException {
+        return TestObjectMapper.get().readValue(json, valueType);
     }
 
     private TestObjectMapper() {} // static class

--- a/module/store-dynamodb/src/testFixtures/java/org/example/age/module/store/dynamodb/testing/DynamoDbTestContainer.java
+++ b/module/store-dynamodb/src/testFixtures/java/org/example/age/module/store/dynamodb/testing/DynamoDbTestContainer.java
@@ -4,8 +4,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.example.age.api.VerifiedUser;
-import org.example.age.common.testing.JsonTesting;
 import org.example.age.common.testing.TestClient;
+import org.example.age.common.testing.TestObjectMapper;
 import org.example.age.module.common.testing.BaseTestContainer;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -60,7 +60,7 @@ public final class DynamoDbTestContainer extends BaseTestContainer<DynamoDbClien
     /** Creates an account on the age verification service. */
     public void createAvsAccount(String accountId, VerifiedUser user) {
         AttributeValue accountIdS = AttributeValue.fromS(accountId);
-        AttributeValue userS = AttributeValue.fromS(JsonTesting.serialize(user));
+        AttributeValue userS = AttributeValue.fromS(TestObjectMapper.serialize(user));
         PutItemRequest userRequest = PutItemRequest.builder()
                 .tableName("Age.User")
                 .item(Map.of("AccountId", accountIdS, "User", userS))

--- a/module/store-redis/src/testFixtures/java/org/example/age/module/store/redis/testing/RedisTestContainer.java
+++ b/module/store-redis/src/testFixtures/java/org/example/age/module/store/redis/testing/RedisTestContainer.java
@@ -1,8 +1,8 @@
 package org.example.age.module.store.redis.testing;
 
 import org.example.age.api.VerifiedUser;
-import org.example.age.common.testing.JsonTesting;
 import org.example.age.common.testing.TestClient;
+import org.example.age.common.testing.TestObjectMapper;
 import org.example.age.module.common.testing.BaseTestContainer;
 import redis.clients.jedis.JedisPooled;
 
@@ -14,7 +14,7 @@ public final class RedisTestContainer extends BaseTestContainer<JedisPooled> {
     /** Creates an account on the age verification service. */
     public void createAvsAccount(String accountId, VerifiedUser user) {
         String redisKey = String.format("age:user:%s", accountId);
-        getClient().set(redisKey, JsonTesting.serialize(user));
+        getClient().set(redisKey, TestObjectMapper.serialize(user));
     }
 
     @Override

--- a/module/test/src/testFixtures/java/org/example/age/module/store/test/FakePendingStore.java
+++ b/module/test/src/testFixtures/java/org/example/age/module/store/test/FakePendingStore.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import org.example.age.common.testing.JsonTesting;
+import org.example.age.common.testing.TestObjectMapper;
 import org.example.age.service.module.store.PendingStore;
 
 /** Fake, in-memory implementation of {@link PendingStore}. Key-value pairs do not expire. */
@@ -21,7 +21,7 @@ final class FakePendingStore<V> implements PendingStore<V> {
 
     @Override
     public CompletionStage<Void> put(String key, Object value, OffsetDateTime expiration) {
-        String jsonValue = JsonTesting.serialize(value);
+        String jsonValue = TestObjectMapper.serialize(value);
         store.put(key, jsonValue);
         return CompletableFuture.completedFuture(null);
     }
@@ -45,7 +45,7 @@ final class FakePendingStore<V> implements PendingStore<V> {
         }
 
         String jsonValue = maybeJsonValue.get();
-        V value = JsonTesting.deserialize(jsonValue, valueType);
+        V value = TestObjectMapper.deserialize(jsonValue, valueType);
         return CompletableFuture.completedFuture(Optional.of(value));
     }
 }


### PR DESCRIPTION
move serialize/deserialize helper methods to `TestObjectMapper`, which is a more logical fit