### PR TITLE
use digests for Docker images + misc

### DIFF
--- a/avs/provider/accountstore-dynamodb/build.gradle.kts
+++ b/avs/provider/accountstore-dynamodb/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
 
 dockerCompose {
     isRequiredBy(tasks.test)
-    useComposeFiles = listOf("$projectDir/docker-compose-test.yml")
-    environment.put("DYNAMODB_VERSION", libs.versions.dockerImages.dynamoDb)
+    useComposeFiles = listOf("docker-compose-test.yml")
+    environment.put("ALPINE_TAG", libs.versions.dockerImages.alpine)
+    environment.put("DYNAMODB_TAG", libs.versions.dockerImages.dynamoDb)
 }

--- a/avs/provider/accountstore-dynamodb/docker-compose-test.yml
+++ b/avs/provider/accountstore-dynamodb/docker-compose-test.yml
@@ -1,17 +1,17 @@
 services:
   dynamodb:
-    image: amazon/dynamodb-local:${DYNAMODB_VERSION}
+    image: amazon/dynamodb-local:${DYNAMODB_TAG}
     command: -jar DynamoDBLocal.jar -sharedDb -dbPath /data
     ports:
       - "8000:8000"
     volumes:
       - dynamodb-data:/data
     depends_on:
-      seed-dynamodb:
+      dynamodb-seed:
         condition: service_completed_successfully
 
-  seed-dynamodb:
-    image: alpine
+  dynamodb-seed:
+    image: alpine:${ALPINE_TAG}
     command: sh -c "cp -r /seed-data/* /data && chmod -R a+rw /data"
     volumes:
       - ./src/test/resources:/seed-data:ro

--- a/avs/provider/accountstore-redis/build.gradle.kts
+++ b/avs/provider/accountstore-redis/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
 
 dockerCompose {
     isRequiredBy(tasks.test)
-    useComposeFiles = listOf("$projectDir/docker-compose-test.yml")
-    environment.put("REDIS_VERSION", libs.versions.dockerImages.redis)
+    useComposeFiles = listOf("docker-compose-test.yml")
+    environment.put("ALPINE_TAG", libs.versions.dockerImages.alpine)
+    environment.put("REDIS_TAG", libs.versions.dockerImages.redis)
 }

--- a/avs/provider/accountstore-redis/docker-compose-test.yml
+++ b/avs/provider/accountstore-redis/docker-compose-test.yml
@@ -1,16 +1,16 @@
 services:
   redis:
-    image: redis:${REDIS_VERSION}
+    image: redis:${REDIS_TAG}
     ports:
       - "6379:6379"
     volumes:
       - redis-data:/data
     depends_on:
-      seed-redis:
+      redis-seed:
         condition: service_completed_successfully
 
-  seed-redis:
-    image: alpine
+  redis-seed:
+    image: alpine:${ALPINE_TAG}
     command: sh -c "cp -r /seed-data/* /data && chmod -R a+rw /data"
     volumes:
       - ./src/test/resources:/seed-data:ro

--- a/common/client/dynamodb/build.gradle.kts
+++ b/common/client/dynamodb/build.gradle.kts
@@ -13,6 +13,6 @@ dependencies {
 
 dockerCompose {
     isRequiredBy(tasks.test)
-    useComposeFiles = listOf("$projectDir/docker-compose-test.yml")
-    environment.put("DYNAMODB_VERSION", libs.versions.dockerImages.dynamoDb)
+    useComposeFiles = listOf("docker-compose-test.yml")
+    environment.put("DYNAMODB_TAG", libs.versions.dockerImages.dynamoDb)
 }

--- a/common/client/dynamodb/docker-compose-test.yml
+++ b/common/client/dynamodb/docker-compose-test.yml
@@ -1,5 +1,5 @@
 services:
   dynamodb:
-    image: amazon/dynamodb-local:${DYNAMODB_VERSION}
+    image: amazon/dynamodb-local:${DYNAMODB_TAG}
     ports:
       - "8000:8000"

--- a/common/client/redis/build.gradle.kts
+++ b/common/client/redis/build.gradle.kts
@@ -12,6 +12,6 @@ dependencies {
 
 dockerCompose {
     isRequiredBy(tasks.test)
-    useComposeFiles = listOf("$projectDir/docker-compose-test.yml")
-    environment.put("REDIS_VERSION", libs.versions.dockerImages.redis)
+    useComposeFiles = listOf("docker-compose-test.yml")
+    environment.put("REDIS_TAG", libs.versions.dockerImages.redis)
 }

--- a/common/client/redis/docker-compose-test.yml
+++ b/common/client/redis/docker-compose-test.yml
@@ -1,5 +1,5 @@
 services:
   redis:
-    image: redis:${REDIS_VERSION}
+    image: redis:${REDIS_TAG}
     ports:
       - "6379:6379"

--- a/common/provider/pendingstore-redis/build.gradle.kts
+++ b/common/provider/pendingstore-redis/build.gradle.kts
@@ -17,6 +17,6 @@ dependencies {
 
 dockerCompose {
     isRequiredBy(tasks.test)
-    useComposeFiles = listOf("$projectDir/docker-compose-test.yml")
-    environment.put("REDIS_VERSION", libs.versions.dockerImages.redis)
+    useComposeFiles = listOf("docker-compose-test.yml")
+    environment.put("REDIS_TAG", libs.versions.dockerImages.redis)
 }

--- a/common/provider/pendingstore-redis/docker-compose-test.yml
+++ b/common/provider/pendingstore-redis/docker-compose-test.yml
@@ -1,5 +1,5 @@
 services:
   redis:
-    image: "redis:${REDIS_VERSION}"
+    image: redis:${REDIS_TAG}
     ports:
       - "6379:6379"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,8 +28,9 @@ errorprone = "2.42.0"
 plugins-spotless-palantir = "2.75.0"
 
 # Docker image
-dockerImages-dynamoDb = "3.1.0"
-dockerImages-redis = "8.2.1"
+dockerImages-alpine = "3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1"
+dockerImages-dynamoDb = "3.1.0@sha256:7ef4a2c45b58c2901e70a4f28e0953a422c2c631baaaf5e2c15e0805740c7752"
+dockerImages-redis = "8.2.1@sha256:5fa2edb1e408fa8235e6db8fab01d1afaaae96c9403ba67b70feceb8661e8621"
 
 [libraries]
 # main: BOMs

--- a/site/provider/accountstore-dynamodb/build.gradle.kts
+++ b/site/provider/accountstore-dynamodb/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
 
 dockerCompose {
     isRequiredBy(tasks.test)
-    useComposeFiles = listOf("$projectDir/docker-compose-test.yml")
-    environment.put("DYNAMODB_VERSION", libs.versions.dockerImages.dynamoDb)
+    useComposeFiles = listOf("docker-compose-test.yml")
+    environment.put("ALPINE_TAG", libs.versions.dockerImages.alpine)
+    environment.put("DYNAMODB_TAG", libs.versions.dockerImages.dynamoDb)
 }

--- a/site/provider/accountstore-dynamodb/docker-compose-test.yml
+++ b/site/provider/accountstore-dynamodb/docker-compose-test.yml
@@ -1,17 +1,17 @@
 services:
   dynamodb:
-    image: amazon/dynamodb-local:${DYNAMODB_VERSION}
+    image: amazon/dynamodb-local:${DYNAMODB_TAG}
     command: -jar DynamoDBLocal.jar -sharedDb -dbPath /data
     ports:
       - "8000:8000"
     volumes:
       - dynamodb-data:/data
     depends_on:
-      seed-dynamodb:
+      dynamodb-seed:
         condition: service_completed_successfully
 
-  seed-dynamodb:
-    image: alpine
+  dynamodb-seed:
+    image: alpine:${ALPINE_TAG}
     command: sh -c "cp -r /seed-data/* /data && chmod -R a+rw /data"
     volumes:
       - ./src/test/resources:/seed-data:ro

--- a/site/provider/accountstore-redis/build.gradle.kts
+++ b/site/provider/accountstore-redis/build.gradle.kts
@@ -17,6 +17,6 @@ dependencies {
 
 dockerCompose {
     isRequiredBy(tasks.test)
-    useComposeFiles = listOf("$projectDir/docker-compose-test.yml")
-    environment.put("REDIS_VERSION", libs.versions.dockerImages.redis)
+    useComposeFiles = listOf("docker-compose-test.yml")
+    environment.put("REDIS_TAG", libs.versions.dockerImages.redis)
 }

--- a/site/provider/accountstore-redis/docker-compose-test.yml
+++ b/site/provider/accountstore-redis/docker-compose-test.yml
@@ -1,5 +1,5 @@
 services:
   redis:
-    image: redis:${REDIS_VERSION}
+    image: redis:${REDIS_TAG}
     ports:
       - "6379:6379"


### PR DESCRIPTION
misc:
- use `TAG` in environment variable name
- new naming convention for seed "services"
- remove redundant `$projectDir`